### PR TITLE
Add RelSRE subfolder dashboards and document the layout

### DIFF
--- a/yardstick/gdg-based/README.md
+++ b/yardstick/gdg-based/README.md
@@ -29,23 +29,58 @@ https://github.com/esnet/gdg
 
 ### RelSRE folder exports
 
-Use `dashboards/relsre/` as the tracked location for Yardstick RelSRE dashboards.
-This mirrors the existing `earthangel/gdg-based/dashboards/relops/` layout while
-keeping the older `yardstick/manual/` files as historical manual exports.
+The RelSRE folder in Yardstick has nested subfolders. Each one maps to a tracked
+directory under `dashboards/`:
 
-After replacing `config/importer.yml` with the 1Password config, use GDG to
-download the RelSRE folder:
+| Yardstick folder | Tracked dir |
+|---|---|
+| `RelSRE` (root) | `dashboards/relsre/` |
+| `RelSRE/FXCI Cloud Workers/Azure` | `dashboards/fxci-cloud-workers/azure/` |
+| `RelSRE/FXCI Cloud Workers/GCP` | `dashboards/fxci-cloud-workers/gcp/` |
+| `RelSRE/FXCI Hardware Workers/Linux` | `dashboards/fxci-hardware-workers/linux/` |
+| `RelSRE/FXCI Hardware Workers/Mac` | `dashboards/fxci-hardware-workers/mac/` |
+| `RelSRE/FXCI Hardware Workers/Windows` | `dashboards/fxci-hardware-workers/windows/` |
+| `RelSRE/RelSRE Development` | `dashboards/relsre-development/` |
+
+`RelSRE/RelSRE Sandboxes` is intentionally not tracked (personal/test dashboards).
+
+`yardstick/manual/` is kept as historical manual exports.
+
+#### Preferred: GDG (when working)
+
+After replacing `config/importer.yml` with the 1Password config, GDG can
+download the RelSRE folder tree:
 
 ```bash
 ./run_gdg.sh backup dash download -f RelSRE
 ```
 
 GDG writes dashboard JSON under the configured output path by Grafana folder.
-Keep the RelSRE exports in `dashboards/relsre/` when committing them to this
-repo. If the local GDG output path differs, copy the downloaded RelSRE dashboard
-JSON into `dashboards/relsre/` before committing.
+Copy the downloaded JSON into the tracked directories above before committing.
 
 Do not run `clear` or delete dashboards as part of a backup/update PR.
+
+#### Fallback: manual via Grafana API
+
+If GDG is not set up locally (no Docker, missing token, etc.), export browser
+cookies for `yardstick.mozilla.org` to a Netscape-format cookie file and pull
+dashboards directly:
+
+```bash
+# list dashboards in a folder
+curl -s -b ~/Downloads/cookies.Mozilla.yardstick.txt \
+  "https://yardstick.mozilla.org/api/search?folderUIDs=<FOLDER_UID>&type=dash-db&limit=500"
+
+# fetch a single dashboard and strip the meta wrapper
+curl -s -b ~/Downloads/cookies.Mozilla.yardstick.txt \
+  "https://yardstick.mozilla.org/api/dashboards/uid/<DASH_UID>" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); \
+      json.dump(d['dashboard'], sys.stdout, indent=2, sort_keys=True)" \
+  > dashboards/<dir>/<slug>.json
+```
+
+Yardstick rotates the session token aggressively; if you see
+`session.token.rotate`, re-export cookies before continuing.
 
 ### misc
 

--- a/yardstick/gdg-based/README.md
+++ b/yardstick/gdg-based/README.md
@@ -82,6 +82,32 @@ curl -s -b ~/Downloads/cookies.Mozilla.yardstick.txt \
 Yardstick rotates the session token aggressively; if you see
 `session.token.rotate`, re-export cookies before continuing.
 
+### Alert rule exports
+
+RelSRE alert rules live in the same Grafana folder as the dashboards they
+monitor (per [the SRE wiki guide](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/1695645862)).
+Backups are tracked alongside the dashboards under `alerts/`, mirroring the
+folder layout above:
+
+```
+yardstick/gdg-based/alerts/
+  relsre/                          # rules in the RelSRE root folder
+  fxci-cloud-workers/{azure,gcp}/  # (empty today)
+  fxci-hardware-workers/{linux,mac,windows}/  # (empty today)
+  relsre-development/              # (empty today)
+```
+
+Pull all rules in the RelSRE tree:
+
+```bash
+curl -s -b ~/Downloads/cookies.Mozilla.yardstick.txt \
+  "https://yardstick.mozilla.org/api/v1/provisioning/alert-rules" \
+  | jq '[.[] | select(.folderUID == "<FOLDER_UID>")]'
+```
+
+Save one JSON per rule (filename = title slug). Strip server-churn fields
+(`id`, `updated`, `version`) before committing so diffs stay clean.
+
 ### misc
 
 ```bash

--- a/yardstick/gdg-based/alerts/relsre/android-em-pending-tasks-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-em-pending-tasks-alert.json
@@ -1,0 +1,157 @@
+{
+  "annotations": {
+    "__dashboardUid__": "_N4y0LpWk",
+    "__panelId__": "13"
+  },
+  "condition": "D",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "sum by () (tc_queue2_prometheus_pending_tasks{provisioner=\"gecko-t\", workerType=~\".*kvm.*\"})",
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "android-em total pending tasks",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "A"
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "tc_queue2_prometheus_pending_tasks{provisioner=\"gecko-t\", workerType=~\".*kvm.*\"}",
+        "instant": false,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "{{provisioner}}/{{workerType}} jobs",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "B"
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "A",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "C",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                7000
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "D"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "C",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "D",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "D",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - PD - Android Hardware TC Queues - Low Priority"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Em - Pending Tasks - Alert",
+  "uid": "fee5rupdkljwge"
+}

--- a/yardstick/gdg-based/alerts/relsre/android-em-pending-tasks-meltdown-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-em-pending-tasks-meltdown-alert.json
@@ -1,0 +1,157 @@
+{
+  "annotations": {
+    "__dashboardUid__": "_N4y0LpWk",
+    "__panelId__": "13"
+  },
+  "condition": "D",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "sum by () (tc_queue2_prometheus_pending_tasks{provisioner=\"gecko-t\", workerType=~\".*kvm.*\"})",
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "android-em total pending tasks",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "A"
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "tc_queue2_prometheus_pending_tasks{provisioner=\"gecko-t\", workerType=~\".*kvm.*\"}",
+        "instant": false,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "{{provisioner}}/{{workerType}} jobs",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "B"
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "A",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "C",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                2000
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "D"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "C",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "D",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "D",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - PD - Meltdown Alerts"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Em - Pending Tasks - Meltdown Alert",
+  "uid": "aee5rbwpxay2ob"
+}

--- a/yardstick/gdg-based/alerts/relsre/android-hw-bitbar-device-health-percentage-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-hw-bitbar-device-health-percentage-alert.json
@@ -1,0 +1,168 @@
+{
+  "annotations": {
+    "__dashboardUid__": "xqkIk8HZz",
+    "__panelId__": "8"
+  },
+  "condition": "C",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "alias": "functioning worker %",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "(sum by() (tc_android_prometheus_worker_health_configured_devices) - sum by() (tc_android_prometheus_worker_health_missing_or_offline_devices)) / sum by() (tc_android_prometheus_worker_health_configured_devices) * 100",
+        "groupBy": [
+          {
+            "params": [
+              "$__interval"
+            ],
+            "type": "time"
+          },
+          {
+            "params": [
+              "none"
+            ],
+            "type": "fill"
+          }
+        ],
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "__auto",
+        "maxDataPoints": 43200,
+        "measurement": "bitbar_workers",
+        "orderByTime": "ASC",
+        "policy": "default",
+        "query": "SELECT ((sum(\"configured\")- sum(\"problem\")) / sum(\"configured\")) * 100  FROM \"bitbar_workers\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+        "range": true,
+        "rawQuery": true,
+        "refId": "A",
+        "resultFormat": "time_series",
+        "select": [
+          [
+            {
+              "params": [
+                "configured"
+              ],
+              "type": "field"
+            },
+            {
+              "params": [],
+              "type": "sum"
+            }
+          ]
+        ],
+        "tags": []
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "A",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                85
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "B",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "C",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - email aerickson"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Hw - Bitbar Device Health Percentage - Alert",
+  "uid": "cee5kch3tqtc0b"
+}

--- a/yardstick/gdg-based/alerts/relsre/android-hw-bitbar-device-health-percentage-meltdown-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-hw-bitbar-device-health-percentage-meltdown-alert.json
@@ -1,0 +1,168 @@
+{
+  "annotations": {
+    "__dashboardUid__": "xqkIk8HZz",
+    "__panelId__": "8"
+  },
+  "condition": "C",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "alias": "functioning worker %",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "(sum by() (tc_android_prometheus_worker_health_configured_devices) - sum by() (tc_android_prometheus_worker_health_missing_or_offline_devices)) / sum by() (tc_android_prometheus_worker_health_configured_devices) * 100",
+        "groupBy": [
+          {
+            "params": [
+              "$__interval"
+            ],
+            "type": "time"
+          },
+          {
+            "params": [
+              "none"
+            ],
+            "type": "fill"
+          }
+        ],
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "__auto",
+        "maxDataPoints": 43200,
+        "measurement": "bitbar_workers",
+        "orderByTime": "ASC",
+        "policy": "default",
+        "query": "SELECT ((sum(\"configured\")- sum(\"problem\")) / sum(\"configured\")) * 100  FROM \"bitbar_workers\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+        "range": true,
+        "rawQuery": true,
+        "refId": "A",
+        "resultFormat": "time_series",
+        "select": [
+          [
+            {
+              "params": [
+                "configured"
+              ],
+              "type": "field"
+            },
+            {
+              "params": [],
+              "type": "sum"
+            }
+          ]
+        ],
+        "tags": []
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "A",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                70
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "B",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "C",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - PD - Meltdown Alerts"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Hw - Bitbar Device Health Percentage - Meltdown Alert",
+  "uid": "dee5kri6iy3ggd"
+}

--- a/yardstick/gdg-based/alerts/relsre/android-hw-pending-tasks-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-hw-pending-tasks-alert.json
@@ -1,0 +1,164 @@
+{
+  "annotations": {
+    "__dashboardUid__": "xqkIk8HZz",
+    "__panelId__": "12"
+  },
+  "condition": "C",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "sum by () (tc_android_prometheus_worker_health_configured_devices)",
+        "instant": false,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "total configured workers",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "A"
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "disableTextWrap": false,
+        "editorMode": "builder",
+        "expr": "sum by() (tc_queue2_prometheus_pending_tasks{provisioner=\"proj-autophone\"})",
+        "fullMetaSearch": false,
+        "includeNullMetadata": true,
+        "instant": false,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "total pending tasks",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "B",
+        "useBackend": false
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0,
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": []
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "name": "Expression",
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "B",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "D",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "D",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                1000,
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": []
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "name": "Expression",
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "D",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "C",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - PD - Android Hardware TC Queues - Low Priority"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Hw - Pending Tasks - Alert",
+  "uid": "eee5ommd02yo0b"
+}

--- a/yardstick/gdg-based/alerts/relsre/android-hw-pending-tasks-meltdown-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-hw-pending-tasks-meltdown-alert.json
@@ -1,0 +1,164 @@
+{
+  "annotations": {
+    "__dashboardUid__": "xqkIk8HZz",
+    "__panelId__": "12"
+  },
+  "condition": "C",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "sum by () (tc_android_prometheus_worker_health_configured_devices)",
+        "instant": false,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "total configured workers",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "A"
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "disableTextWrap": false,
+        "editorMode": "builder",
+        "expr": "sum by() (tc_queue2_prometheus_pending_tasks{provisioner=\"proj-autophone\"})",
+        "fullMetaSearch": false,
+        "includeNullMetadata": true,
+        "instant": false,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "total pending tasks",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "B",
+        "useBackend": false
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0,
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": []
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "name": "Expression",
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "B",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "D",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "D",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                1000,
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": []
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "name": "Expression",
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "D",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "C",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - PD - Meltdown Alerts"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Hw - Pending Tasks - Meltdown Alert",
+  "uid": "dee5ophusmps0e"
+}

--- a/yardstick/gdg-based/alerts/relsre/android-hw-pending-tasks-perf-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-hw-pending-tasks-perf-alert.json
@@ -1,0 +1,229 @@
+{
+  "annotations": {
+    "__dashboardUid__": "NSKyosMZz",
+    "__panelId__": "6"
+  },
+  "condition": "D",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "alias": "$tag_queue",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "disableTextWrap": false,
+        "editorMode": "code",
+        "expr": "tc_queue2_prometheus_pending_tasks{provisioner=\"proj-autophone\", workerType=~\".*perf.*\"}",
+        "fullMetaSearch": false,
+        "groupBy": [
+          {
+            "params": [
+              "queue"
+            ],
+            "type": "tag"
+          }
+        ],
+        "includeNullMetadata": true,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "{{workerType}} pending tasks",
+        "maxDataPoints": 43200,
+        "measurement": "current",
+        "orderByTime": "ASC",
+        "policy": "default",
+        "query": "SELECT * FROM \"bitbar_queue_size\" WHERE $timeFilter and queue =~/perf/ GROUP BY \"queue\";\n",
+        "range": true,
+        "rawQuery": true,
+        "refId": "A",
+        "resultFormat": "time_series",
+        "select": [
+          [
+            {
+              "params": [
+                "value"
+              ],
+              "type": "field"
+            }
+          ]
+        ],
+        "tags": [
+          {
+            "key": "queue",
+            "operator": "=",
+            "value": "gecko-t-ap-batt-g5"
+          }
+        ],
+        "useBackend": false
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "alias": "$tag_queue",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "disableTextWrap": false,
+        "editorMode": "code",
+        "expr": "sum by () (tc_queue2_prometheus_pending_tasks{provisioner=\"proj-autophone\", workerType=~\".*perf.*\"})",
+        "fullMetaSearch": false,
+        "groupBy": [
+          {
+            "params": [
+              "queue"
+            ],
+            "type": "tag"
+          }
+        ],
+        "includeNullMetadata": true,
+        "instant": false,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "total pending perf tasks",
+        "maxDataPoints": 43200,
+        "measurement": "current",
+        "orderByTime": "ASC",
+        "policy": "default",
+        "query": "SELECT * FROM \"bitbar_queue_size\" WHERE $timeFilter and queue =~/perf/ GROUP BY \"queue\";\n",
+        "range": true,
+        "rawQuery": true,
+        "refId": "B",
+        "resultFormat": "time_series",
+        "select": [
+          [
+            {
+              "params": [
+                "value"
+              ],
+              "type": "field"
+            }
+          ]
+        ],
+        "tags": [
+          {
+            "key": "queue",
+            "operator": "=",
+            "value": "gecko-t-ap-batt-g5"
+          }
+        ],
+        "useBackend": false
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "B",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "C",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                1000
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "D"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "C",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "D",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "D",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - PD - Android Hardware TC Queues - Low Priority"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Hw - Pending Tasks (Perf) - Alert",
+  "uid": "fee5pxixikc1sc"
+}

--- a/yardstick/gdg-based/alerts/relsre/android-hw-quarantined-workers-alert.json
+++ b/yardstick/gdg-based/alerts/relsre/android-hw-quarantined-workers-alert.json
@@ -1,0 +1,164 @@
+{
+  "annotations": {
+    "__dashboardUid__": "xqkIk8HZz",
+    "__panelId__": "13"
+  },
+  "condition": "D",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "disableTextWrap": false,
+        "editorMode": "code",
+        "expr": "sum by() (tc_queue2_prometheus_quarantined_workers{provisioner=\"proj-autophone\"})",
+        "fullMetaSearch": false,
+        "includeNullMetadata": true,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "total quarantined workers",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "B",
+        "useBackend": false
+      },
+      "queryType": "",
+      "refId": "B",
+      "relativeTimeRange": {
+        "from": 172800,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "disableTextWrap": false,
+        "editorMode": "code",
+        "expr": "sum by(workerType) (tc_queue2_prometheus_quarantined_workers{provisioner=\"proj-autophone\"})",
+        "fullMetaSearch": false,
+        "includeNullMetadata": true,
+        "interval": "",
+        "intervalMs": 30000,
+        "legendFormat": "{{workerType}} quarantined workers",
+        "maxDataPoints": 43200,
+        "range": true,
+        "refId": "A",
+        "useBackend": false
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 172800,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "B",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "reducer": "last",
+        "refId": "C",
+        "type": "reduce"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                10
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "D"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "C",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "D",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "D",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "1m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "Release SRE - PD - Android Hardware TC Queues - Low Priority"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "Android Hw - Quarantined Workers - Alert",
+  "uid": "aee5svu78bh8gb"
+}

--- a/yardstick/gdg-based/alerts/relsre/queues-with-1-tasks-and-no-running-workers.json
+++ b/yardstick/gdg-based/alerts/relsre/queues-with-1-tasks-and-no-running-workers.json
@@ -1,0 +1,91 @@
+{
+  "annotations": {
+    "__dashboardUid__": "ieg6Sho5",
+    "__panelId__": "10",
+    "summary": "queues with 1+ tasks and no running workers: {{index $labels \"provisionerId\"}}/{{index $labels \"workerType\"}}"
+  },
+  "condition": "C",
+  "data": [
+    {
+      "datasourceUid": "cdq6ttvymu4g0c",
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "cdq6ttvymu4g0c"
+        },
+        "editorMode": "code",
+        "expr": "# Alert: Pending Tasks Without Workers\n# OWNER: aerickson\n#\n# This alert detects situations where there are **pending tasks but no running workers**\n# for a given (provisionerId, workerType) pool.\n#\n# How it works:\n# 1. `sum by (provisionerId, workerType) (fxci_queue_pending_tasks) >= X`\n#    - Selects pools with more than or equal X pending tasks. \n#    - Threshold is >1 (instead of >0) to avoid false positives from \n#      transient tasks (e.g., tc \"probe\" tasks that sit and timeout).\n#    - Raised to 10 to only alert on queues we (releng/relops) have created (vs queues where\n#      a developer just submitted something).\n# 2. `sum by (provisionerId, workerType) (fxci_queue_running_workers) > 0`\n#    - Selects pools that currently have one or more running workers.\n# 3. `A unless on (...) B`\n#    - Returns only the `pending` pools that do **not** have any running workers.\n#\n# Filters:\n# - worker-type\n#.  - test-1 (android hw test pool)\n#   - unit-p6 (android hw pool that shouldn't have tasks)\n#   - alpha (non-prod pools)\n#\n# Expected behavior:\n# - If no pools are in trouble, the query returns nothing. Grafana will show this as \"no data\".\n#   This is normal and should be treated as OK in alert settings.\n# - If a pool has >1 pending task and zero running workers, the query will emit that pool\u2019s labels,\n#   triggering the alert.\n#\n(\n  sum by (provisionerId, workerType)\n    (fxci_queue_pending_tasks{workerType!~\"^.*(test.*|unit-p6|-alpha)$\"}) >= 10\n)\nunless on (provisionerId, workerType)\n(\n  sum by (provisionerId, workerType)\n    (fxci_queue_running_workers{workerType!~\"^.*(test-1|unit-p6|-alpha)$\"}) > 0\n)\n",
+        "format": "time_series",
+        "instant": true,
+        "intervalMs": 1000,
+        "legendFormat": "{{provisionerId}}/{{workerType}} tasks",
+        "maxDataPoints": 43200,
+        "range": false,
+        "refId": "A"
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 600,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0,
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": []
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "name": "Expression",
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "A",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "C",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Alerting",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "45m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "OK",
+  "notification_settings": {
+    "receiver": "releng - slack tf"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "queues with 1+ tasks and no running workers",
+  "uid": "fewinj1g1wni8e"
+}

--- a/yardstick/gdg-based/alerts/relsre/relops-android-hw-lt-alert-low-workers.json
+++ b/yardstick/gdg-based/alerts/relsre/relops-android-hw-lt-alert-low-workers.json
@@ -1,0 +1,93 @@
+{
+  "annotations": {
+    "__dashboardUid__": "xqkIk8HZz",
+    "__panelId__": "14",
+    "runbook_url": "https://mozilla-hub.atlassian.net/wiki/spaces/ROPS/pages/26477052/Android+Build+and+Test+Infrastructure#Operational-Runbook",
+    "summary": "low number of workers currently working, cc @aerickson"
+  },
+  "condition": "C",
+  "data": [
+    {
+      "datasourceUid": "adpvtjmrxoc1sb",
+      "model": {
+        "adhocFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "editorMode": "code",
+        "expr": "\n  avg_over_time(\n    fxci_queue_workers_total{provisionerId=\"proj-autophone\", workerType=\"gecko-t-lambda-perf-a55\"}[1m]\n  )\n\n",
+        "instant": true,
+        "interval": "",
+        "intervalMs": 15000,
+        "legendFormat": "{{workerType}}",
+        "maxDataPoints": 43200,
+        "range": false,
+        "refId": "A"
+      },
+      "queryType": "",
+      "refId": "A",
+      "relativeTimeRange": {
+        "from": 86400,
+        "to": 0
+      }
+    },
+    {
+      "datasourceUid": "__expr__",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                42
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "__expr__"
+        },
+        "expression": "A",
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "C",
+        "type": "threshold"
+      },
+      "queryType": "",
+      "refId": "C",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      }
+    }
+  ],
+  "execErrState": "Error",
+  "folderUID": "edtgaia1z6waoe",
+  "for": "10m",
+  "isPaused": false,
+  "keep_firing_for": "0s",
+  "noDataState": "NoData",
+  "notification_settings": {
+    "receiver": "releng - slack tf"
+  },
+  "orgID": 1,
+  "record": null,
+  "ruleGroup": "1m",
+  "title": "RelOps - Android HW/LT Alert - Low Workers",
+  "uid": "af7vyfkncwpa8e"
+}

--- a/yardstick/gdg-based/dashboards/fxci-cloud-workers/azure/azure-worker-pools-hourly-queue-peak-avg-pickup-wait.json
+++ b/yardstick/gdg-based/dashboards/fxci-cloud-workers/azure/azure-worker-pools-hourly-queue-peak-avg-pickup-wait.json
@@ -1,0 +1,265 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1124,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Hourly peak queue depth and hourly average estimated pickup wait, per Azure worker pool (active in the last 24h)",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "description": "Hourly peak queued tasks and hourly average estimated pickup wait for pool **${pool}** (Azure). Both computed over rolling 1h windows sampled every 5 minutes.\n\n- **Hourly Peak Queued** \u2014 `max_over_time(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"}[1h:5m])`. Highest pending-task count for the pool in the last hour. Left axis, count.\n- **Hourly Avg Time to Pickup** \u2014 `avg_over_time((pending / rate(completed[15m]) / 60)[1h:5m])`. Pending sourced from `fxci_worker_manager_pending_tasks` (filtered by `workerPoolId`); completion rate sourced from `fxci_queue_completed_tasks` joined via `label_join` on `provisionerId/workerType`. Right axis, minutes.\n\nVariable scope: only workerPoolIds that had `existing_capacity > 0` at some point in the last 24h are listed (filters out dead/legacy pools).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Peak Queued"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Tasks queued"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Avg Time to Pickup"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "m"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Pickup wait (min)"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "max_over_time(sum(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"})[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Peak Queued",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "avg_over_time((\n  (\n    sum(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"})\n    /\n    (sum(\n      label_join(rate(fxci_queue_completed_tasks[15m]), \"workerPoolId\", \"/\", \"provisionerId\", \"workerType\")\n      * on(workerPoolId) group_left()\n      (0 * fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"} + 1)\n    ) > 0)\n    / 60\n  )\n  or\n  (sum(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"}) == 0)\n)[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Avg Time to Pickup",
+              "refId": "B"
+            }
+          ],
+          "title": "",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "pool",
+      "title": "${pool}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "fxci",
+    "azure",
+    "cloud",
+    "pickup-wait",
+    "timeline"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "definition": "query_result(group by (workerPoolId) (max_over_time(fxci_worker_manager_existing_capacity{providerId=~\"azure.*\"}[24h]) > 0))",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(group by (workerPoolId) (max_over_time(fxci_worker_manager_existing_capacity{providerId=~\"azure.*\"}[24h]) > 0))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/workerPoolId=\"([^\"]+)\"/",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Azure Worker Pools \u2014 Hourly Queue Peak & Avg Pickup Wait",
+  "uid": "azure-pickup-wait-timeline-v1",
+  "version": 2
+}

--- a/yardstick/gdg-based/dashboards/fxci-cloud-workers/gcp/gcp-worker-pools-hourly-queue-peak-avg-pickup-wait.json
+++ b/yardstick/gdg-based/dashboards/fxci-cloud-workers/gcp/gcp-worker-pools-hourly-queue-peak-avg-pickup-wait.json
@@ -1,0 +1,265 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1123,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Hourly peak queue depth and hourly average estimated pickup wait, per GCP worker pool (active in the last 24h)",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "description": "Hourly peak queued tasks and hourly average estimated pickup wait for pool **${pool}** (GCP). Both computed over rolling 1h windows sampled every 5 minutes.\n\n- **Hourly Peak Queued** \u2014 `max_over_time(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"}[1h:5m])`. Highest pending-task count for the pool in the last hour. Left axis, count.\n- **Hourly Avg Time to Pickup** \u2014 `avg_over_time((pending / rate(completed[15m]) / 60)[1h:5m])`. Pending sourced from `fxci_worker_manager_pending_tasks` (filtered by `workerPoolId`); completion rate sourced from `fxci_queue_completed_tasks` joined via `label_join` on `provisionerId/workerType`. Right axis, minutes.\n\nVariable scope: only workerPoolIds that had `existing_capacity > 0` at some point in the last 24h are listed (filters out dead/legacy pools).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Peak Queued"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Tasks queued"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Avg Time to Pickup"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "m"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Pickup wait (min)"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "max_over_time(sum(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"})[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Peak Queued",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "avg_over_time((\n  (\n    sum(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"})\n    /\n    (sum(\n      label_join(rate(fxci_queue_completed_tasks[15m]), \"workerPoolId\", \"/\", \"provisionerId\", \"workerType\")\n      * on(workerPoolId) group_left()\n      (0 * fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"} + 1)\n    ) > 0)\n    / 60\n  )\n  or\n  (sum(fxci_worker_manager_pending_tasks{workerPoolId=\"${pool}\"}) == 0)\n)[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Avg Time to Pickup",
+              "refId": "B"
+            }
+          ],
+          "title": "",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "pool",
+      "title": "${pool}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "fxci",
+    "gcp",
+    "cloud",
+    "pickup-wait",
+    "timeline"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "definition": "query_result(group by (workerPoolId) (max_over_time(fxci_worker_manager_existing_capacity{providerId=~\"fxci-.*-gcp\"}[24h]) > 0))",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(group by (workerPoolId) (max_over_time(fxci_worker_manager_existing_capacity{providerId=~\"fxci-.*-gcp\"}[24h]) > 0))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/workerPoolId=\"([^\"]+)\"/",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "GCP Worker Pools \u2014 Hourly Queue Peak & Avg Pickup Wait",
+  "uid": "gcp-pickup-wait-timeline-v1",
+  "version": 2
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/linux/linux-all-metrics.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/linux/linux-all-metrics.json
@@ -1,0 +1,418 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1098,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host CPU, memory, disk, and network latency timeseries for Linux moonshot workers",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "CPU utilization for host **${hostname}** (Linux). Single series, 0\u2013100%.\n\n**Series:**\n- **CPU %** \u2014 `snmp-load-average` check, metric `cpu_prct_used`.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "CPU %",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-load\" and r.service == \"snmp-load-average\" and r.metric == \"cpu_prct_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"CPU %\" }))\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Memory and disk usage for host **${hostname}** (Linux). Bytes (decimal).\n\n**Series:**\n- **RAM Used** \u2014 `snmp-memory-usage`, metric `ram_used` (KB \u2192 bytes).\n- **Swap Used** \u2014 `snmp-memory-usage`, metric `swap_used` (KB \u2192 bytes).\n- **Disk <metric>** \u2014 `snmp-disk` (measurement `snmp-storage`); one series per disk metric tag (e.g., `used`, `total`).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Bytes",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 3
+          },
+          "id": 202,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "ram = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"ram_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"RAM Used\"}))\n\nswap = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"swap_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"Swap Used\"}))\n\ndisk = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-storage\" and r.service == \"snmp-disk\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value), series: \"Disk \" + r.metric}))\n\nunion(tables: [ram, swap, disk])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory and Disk",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Network round-trip and SSH connection time for host **${hostname}** (Linux), milliseconds.\n\n**Series:**\n- **Ping RTA** \u2014 `hostalive` ping round-trip time (ms).\n- **SSH Time** \u2014 `ssh` check connection time (scaled to ms).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Milliseconds",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 3
+          },
+          "id": 203,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "rta = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r.metric == \"rta\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"Ping RTA\" }))\n\nsshTime = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"ssh\" and r.service == \"ssh\" and r.metric == \"time\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value) * 1000.0, series: \"SSH Time\" }))\n\nunion(tables: [rta, sshTime])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Network Latency",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "hostname",
+      "repeatDirection": "v",
+      "title": "${hostname}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "linux",
+    "moonshot",
+    "metrics",
+    "cpu",
+    "ram",
+    "disk"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Linux All Metrics",
+  "uid": "linux-all-metrics-v1",
+  "version": 6
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/linux/linux-all-status.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/linux/linux-all-status.json
@@ -1,0 +1,1212 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1097,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host status for Linux moonshot workers \u2014 pool/host filters apply to all panels below",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-host status for pool **${pool}** (Linux/moonshot). One row per host expected to report (anchored on `hostalive` over the last 1h, host filter `^t-linux`). Service columns show the last state in the last 10 minutes. Grey \u25cf = no data / host fell off the short window.\n\n**Columns:**\n- **Hostname** \u2014 FQDN of the Linux worker as Icinga reports it.\n- **Up** \u2014 `hostalive` state. Green=Up, Red=Down, Yellow=Unreachable, Grey=no data.\n- **SSH** \u2014 `ssh` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Load** \u2014 `snmp-load-average` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Memory** \u2014 `snmp-memory-usage` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Disk** \u2014 `snmp-disk` check (measurement `snmp-storage`). Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **GW** \u2014 `Linux Generic Worker` check (measurement `snmp_gw_status`). Green=OK (taking work), Yellow=Warn, Red=Crit, Grey=Unknown/no data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hostname"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hostname"
+              },
+              {
+                "id": "custom.width",
+                "value": 360
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Up"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SSH"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Load"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 80
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disk"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GW"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 410,
+      "maxPerRow": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "repeat": "pool",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^t-linux/\n\nexpectedHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npool = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Pool\", v: r._value}))\n\nup = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Up\", v: string(v: r._value)}))\n\nmkService = (m, s, col) =>\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -10m)\n    |> filter(fn: (r) => r._measurement == m and r.service == s and r._field == \"state\")\n    |> filter(fn: hostFilter)\n    |> last()\n    |> map(fn: (r) => ({hostname: r.hostname, k: col, v: string(v: r._value)}))\n\nssh = mkService(m: \"ssh\", s: \"ssh\", col: \"SSH\")\nload = mkService(m: \"snmp-load\", s: \"snmp-load-average\", col: \"Load\")\nmem = mkService(m: \"snmp-memory\", s: \"snmp-memory-usage\", col: \"Memory\")\ndisk = mkService(m: \"snmp-storage\", s: \"snmp-disk\", col: \"Disk\")\ngw = mkService(m: \"snmp_gw_status\", s: \"Linux Generic Worker\", col: \"GW\")\n\nunion(tables: [expectedHosts, pool, up, ssh, load, mem, disk, gw])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       Pool: if exists r.Pool then r.Pool else \"Unknown\",\n       Up: if exists r.Up then r.Up else \"\",\n       SSH: if exists r.SSH then r.SSH else \"\",\n       Load: if exists r.Load then r.Load else \"\",\n       Memory: if exists r.Memory then r.Memory else \"\",\n       Disk: if exists r.Disk then r.Disk else \"\",\n       GW: if exists r.GW then r.GW else \"\"\n     }))\n  |> filter(fn: (r) => r.Pool == \"${pool}\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> sort(columns: [\"hostname\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "${pool}",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Pool": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Disk": 5,
+              "GW": 6,
+              "Load": 3,
+              "Memory": 4,
+              "SSH": 2,
+              "Up": 0,
+              "hostname": 1
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-pool count of Linux workers (`^t-linux`) currently Available vs. Not Available, based on the Linux Generic Worker (`snmp_gw_status`) check state in the last 15 minutes.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID from the `host_pool` InfluxDB measurement. Hosts without a pool record are bucketed as `Unknown`.\n- **Available (15 Minute Window)** \u2014 count of hosts whose Linux Generic Worker check reported OK (state=0) at any point in the last 15 minutes.\n- **Not Available** \u2014 count of hosts whose Linux Generic Worker check did NOT report OK in the last 15 minutes (warn/crit/unknown or no data).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.wrapHeaderText",
+                "value": true
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              },
+              {
+                "id": "displayName",
+                "value": "Available (15 Minute Window)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Not Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 2
+      },
+      "id": 500,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Available",
+            "Not Available"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^t-linux/\n\nallHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npoolRecords = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"pool\", v: r._value}))\n\ngwAvailability = from(bucket: \"marlin-icinga2\")\n  |> range(start: -15m)\n  |> filter(fn: (r) => r._measurement == \"snmp_gw_status\" and r.service == \"Linux Generic Worker\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> group(columns: [\"hostname\"])\n  |> min(column: \"_value\")\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"gwAvail\", v: if r._value == 0 then \"yes\" else \"no\"}))\n\ncombined = union(tables: [allHosts, poolRecords, gwAvailability])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       pool: if exists r.pool then r.pool else \"Unknown\",\n       gwAvail: if exists r.gwAvail then r.gwAvail else \"no\"\n     }))\n\navailable = combined\n  |> filter(fn: (r) => r.gwAvail == \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Available\", n: r.hostname}))\n\nnotAvailable = combined\n  |> filter(fn: (r) => r.gwAvail != \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Not Available\", n: r.hostname}))\n\nunion(tables: [available, notAvailable])\n  |> group()\n  |> pivot(rowKey: [\"pool\"], columnKey: [\"kind\"], valueColumn: \"n\")\n  |> map(fn: (r) => ({\n       pool: r.pool,\n       Available: if exists r.Available then r.Available else 0,\n       \"Not Available\": if exists r[\"Not Available\"] then r[\"Not Available\"] else 0\n     }))\n  |> sort(columns: [\"pool\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Available": 1,
+              "Not Available": 2,
+              "pool": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "Live queue depth and worker activity per Linux pool, sourced from Prometheus (`fxci_queue_*` metrics). Filtered to `provisionerId=releng-hardware`, `workerType=~gecko-t-linux-.*`.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID derived from the Prometheus `workerType` label.\n- **Active** \u2014 `fxci_queue_running_workers`: current count of running workers.\n- **Queue** \u2014 `fxci_queue_pending_tasks`: current count of pending tasks.\n- **24h Peak** \u2014 `max_over_time(...[24h:])` of pending tasks; highest queue depth seen in the last 24 hours.\n- **Avg Task Age (min)** \u2014 estimated average age of currently-pending tasks (time spent waiting in the queue). Computed via Little's Law: `pending / rate(completed[1h]) / 60`. Steady-state proxy \u2014 we don't have per-task timestamps, so this is the expected wait under current throughput, not a true measurement. Idle pools (pending=0) show **0.0**; pools with a backlog but no completions in the last hour show \u2014.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "gray",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "24h Peak"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Task Age (min)"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 170
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "noValue",
+                "value": "\u2014"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "\u2014"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 2
+      },
+      "id": 510,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Queue",
+            "Active"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_running_workers{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "max_over_time(sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))[24h:])",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "(\n  sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))\n  /\n  (sum by (pool) (label_replace(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}[1h]), \"pool\", \"$1\", \"workerType\", \"(.*)\")) > 0)\n  / 60\n)\nor\nsum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\")) == 0",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "Pool Queues",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "pool",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true
+            },
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 1,
+              "Value #C": 3,
+              "Value #D": 4,
+              "pool": 0
+            },
+            "renameByName": {
+              "Value #A": "Queue",
+              "Value #B": "Active",
+              "Value #C": "24h Peak",
+              "Value #D": "Avg Task Age (min)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "linux",
+    "moonshot",
+    "status"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "import \"experimental/array\"\n\nactualPools = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> map(fn: (r) => ({_value: r._value, sk: \"0_\" + r._value}))\n\nunknownRow = array.from(rows: [{_value: \"Unknown\", sk: \"1_Unknown\"}])\n\nunion(tables: [actualPools, unknownRow])\n  |> sort(columns: [\"sk\"])\n  |> keep(columns: [\"_value\"])",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "import \"experimental/array\"\n\nactualPools = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> map(fn: (r) => ({_value: r._value, sk: \"0_\" + r._value}))\n\nunknownRow = array.from(rows: [{_value: \"Unknown\", sk: \"1_Unknown\"}])\n\nunion(tables: [actualPools, unknownRow])\n  |> sort(columns: [\"sk\"])\n  |> keep(columns: [\"_value\"])",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\" and r.hostname =~ /^t-linux/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Linux All Status",
+  "uid": "linux-all-status-v1",
+  "version": 16
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/linux/linux-worker-pools-hourly-queue-peak-avg-pickup-wait.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/linux/linux-worker-pools-hourly-queue-peak-avg-pickup-wait.json
@@ -1,0 +1,264 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1118,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Hourly peak queue depth and hourly average estimated pickup wait, per Linux releng-hardware worker pool",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "description": "Hourly peak queued tasks and hourly average estimated pickup wait for pool **${pool}** (Linux / releng-hardware). Both computed over rolling 1h windows sampled every 5 minutes.\n\n- **Hourly Peak Queued** \u2014 `max_over_time(pending_tasks[1h:5m])`. Highest pending-task count seen in the last hour. Left axis, count.\n- **Hourly Avg Time to Pickup** \u2014 `avg_over_time((pending / rate(completed[15m]) / 60)[1h:5m])`. Average Little's Law pickup-wait estimate (minutes) over the last hour. Right axis, minutes. Idle pools (pending=0) show 0; steady-state assumption applies.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Peak Queued"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Tasks queued"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Avg Time to Pickup"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "m"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Pickup wait (min)"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "max_over_time(sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"})[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Peak Queued",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "avg_over_time((\n  (\n    sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"})\n    /\n    (sum(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"}[15m])) > 0)\n    / 60\n  )\n  or\n  (sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"}) == 0)\n)[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Avg Time to Pickup",
+              "refId": "B"
+            }
+          ],
+          "title": "",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "pool",
+      "title": "${pool}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "linux",
+    "moonshot",
+    "releng-hardware",
+    "pickup-wait",
+    "timeline"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "definition": "label_values(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}, workerType)",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "label_values(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\"gecko-t-linux-.*\"}, workerType)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Linux Worker Pools \u2014 Hourly Queue Peak & Avg Pickup Wait",
+  "uid": "linux-pickup-wait-timeline-v1",
+  "version": 5
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-builders-metrics.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-builders-metrics.json
@@ -1,0 +1,419 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1113,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host CPU, memory, disk, and network latency timeseries for Mac builder workers",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "CPU utilization for host **${hostname}** (macOS). Single series, 0\u2013100%.\n\n**Series:**\n- **CPU %** \u2014 `snmp-load-average` check, metric `cpu_prct_used`.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "CPU %",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-load\" and r.service == \"snmp-load-average\" and r.metric == \"cpu_prct_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"CPU %\" }))\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Memory and disk usage for host **${hostname}** (macOS). Bytes (decimal).\n\n**Series:**\n- **RAM Used** \u2014 `snmp-memory-usage`, metric `ram_used` (KB \u2192 bytes).\n- **Swap Used** \u2014 `snmp-memory-usage`, metric `swap_used` (KB \u2192 bytes).\n- **Disk <metric>** \u2014 `snmp-disk` (measurement `snmp-storage`); one series per disk metric tag (e.g., `used`, `total`).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Bytes",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 3
+          },
+          "id": 202,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "ram = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"ram_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"RAM Used\"}))\n\nswap = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"swap_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"Swap Used\"}))\n\ndisk = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-storage\" and r.service == \"snmp-disk\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value), series: \"Disk \" + r.metric}))\n\nunion(tables: [ram, swap, disk])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory and Disk",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Network round-trip and SSH connection time for host **${hostname}** (macOS), milliseconds.\n\n**Series:**\n- **Ping RTA** \u2014 `hostalive` ping round-trip time (ms).\n- **SSH Time** \u2014 `ssh` check connection time (scaled to ms).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Milliseconds",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 3
+          },
+          "id": 203,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "rta = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r.metric == \"rta\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"Ping RTA\" }))\n\nsshTime = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"ssh\" and r.service == \"ssh\" and r.metric == \"time\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value) * 1000.0, series: \"SSH Time\" }))\n\nunion(tables: [rta, sshTime])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Network Latency",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "hostname",
+      "repeatDirection": "v",
+      "title": "${hostname}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "mac",
+    "macos",
+    "metrics",
+    "cpu",
+    "ram",
+    "disk",
+    "builders"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mac Builders Metrics",
+  "uid": "mac-builders-metrics-v1",
+  "version": 1
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-builders-status.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-builders-status.json
@@ -1,0 +1,1213 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1112,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host status for Mac builder workers \u2014 pool/host filters apply to all panels below",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-host status for pool **${pool}** (Mac builder; matches `-b-` in pool name). One row per host expected to report (anchored on `hostalive` over the last 1h, host filter `^macmini-`). Service columns show the last state in the last 10 minutes. Grey \u25cf = no data / host fell off the short window.\n\n**Columns:**\n- **Hostname** \u2014 FQDN of the Mac worker as Icinga reports it.\n- **Up** \u2014 `hostalive` state. Green=Up, Red=Down, Yellow=Unreachable, Grey=no data.\n- **SSH** \u2014 `ssh` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Load** \u2014 `snmp-load-average` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Memory** \u2014 `snmp-memory-usage` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Disk** \u2014 `snmp-disk` check (measurement `snmp-storage`). Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **GW** \u2014 `Mac Generic Worker` check (measurement `snmp_gw_status`). Green=OK (taking work), Yellow=Warn, Red=Crit, Grey=Unknown/no data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hostname"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hostname"
+              },
+              {
+                "id": "custom.width",
+                "value": 360
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Up"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SSH"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Load"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 80
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disk"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GW"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 410,
+      "maxPerRow": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "repeat": "pool",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^macmini-/\n\nexpectedHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npool = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Pool\", v: r._value}))\n\nup = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Up\", v: string(v: r._value)}))\n\nmkService = (m, s, col) =>\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -10m)\n    |> filter(fn: (r) => r._measurement == m and r.service == s and r._field == \"state\")\n    |> filter(fn: hostFilter)\n    |> last()\n    |> map(fn: (r) => ({hostname: r.hostname, k: col, v: string(v: r._value)}))\n\nssh = mkService(m: \"ssh\", s: \"ssh\", col: \"SSH\")\nload = mkService(m: \"snmp-load\", s: \"snmp-load-average\", col: \"Load\")\nmem = mkService(m: \"snmp-memory\", s: \"snmp-memory-usage\", col: \"Memory\")\ndisk = mkService(m: \"snmp-storage\", s: \"snmp-disk\", col: \"Disk\")\ngw = mkService(m: \"snmp_gw_status\", s: \"Mac Generic Worker\", col: \"GW\")\n\nunion(tables: [expectedHosts, pool, up, ssh, load, mem, disk, gw])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       Pool: if exists r.Pool then r.Pool else \"Unknown\",\n       Up: if exists r.Up then r.Up else \"\",\n       SSH: if exists r.SSH then r.SSH else \"\",\n       Load: if exists r.Load then r.Load else \"\",\n       Memory: if exists r.Memory then r.Memory else \"\",\n       Disk: if exists r.Disk then r.Disk else \"\",\n       GW: if exists r.GW then r.GW else \"\"\n     }))\n  |> filter(fn: (r) => r.Pool == \"${pool}\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> sort(columns: [\"hostname\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "${pool}",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Pool": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Disk": 5,
+              "GW": 6,
+              "Load": 3,
+              "Memory": 4,
+              "SSH": 2,
+              "Up": 0,
+              "hostname": 1
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-pool count of Mac builder workers (pool name matches `-b-`) currently Available vs. Not Available, based on the Mac Generic Worker (`snmp_gw_status`) check state in the last 15 minutes.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID from the `host_pool` InfluxDB measurement.\n- **Available (15 Minute Window)** \u2014 count of builder hosts whose Mac Generic Worker check reported OK (state=0) at any point in the last 15 minutes.\n- **Not Available** \u2014 count of builder hosts whose Mac Generic Worker check did NOT report OK in the last 15 minutes (warn/crit/unknown or no data).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.wrapHeaderText",
+                "value": true
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              },
+              {
+                "id": "displayName",
+                "value": "Available (15 Minute Window)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Not Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 2
+      },
+      "id": 500,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Available",
+            "Not Available"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^macmini-/\n\nallHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npoolRecords = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"pool\", v: r._value}))\n\ngwAvailability = from(bucket: \"marlin-icinga2\")\n  |> range(start: -15m)\n  |> filter(fn: (r) => r._measurement == \"snmp_gw_status\" and r.service == \"Mac Generic Worker\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> group(columns: [\"hostname\"])\n  |> min(column: \"_value\")\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"gwAvail\", v: if r._value == 0 then \"yes\" else \"no\"}))\n\ncombined = union(tables: [allHosts, poolRecords, gwAvailability])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       pool: if exists r.pool then r.pool else \"Unknown\",\n       gwAvail: if exists r.gwAvail then r.gwAvail else \"no\"\n     }))\n\navailable = combined\n  |> filter(fn: (r) => r.gwAvail == \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Available\", n: r.hostname}))\n\nnotAvailable = combined\n  |> filter(fn: (r) => r.gwAvail != \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Not Available\", n: r.hostname}))\n\nunion(tables: [available, notAvailable])\n  |> group()\n  |> pivot(rowKey: [\"pool\"], columnKey: [\"kind\"], valueColumn: \"n\")\n  |> map(fn: (r) => ({\n       pool: r.pool,\n       Available: if exists r.Available then r.Available else 0,\n       \"Not Available\": if exists r[\"Not Available\"] then r[\"Not Available\"] else 0\n     }))\n  |> filter(fn: (r) => r.pool =~ /-b-/)\n  |> sort(columns: [\"pool\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Available": 1,
+              "Not Available": 2,
+              "pool": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "Live queue depth and worker activity per Mac builder pool, sourced from Prometheus (`fxci_queue_*` metrics). Filtered to `provisionerId=releng-hardware`, `workerType=~.*osx.*`, `workerType=~.*-b-.*`.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID derived from the Prometheus `workerType` label.\n- **Active** \u2014 `fxci_queue_running_workers`: current count of running workers.\n- **Queue** \u2014 `fxci_queue_pending_tasks`: current count of pending tasks.\n- **24h Peak** \u2014 `max_over_time(...[24h:])` of pending tasks; highest queue depth seen in the last 24 hours.\n- **Avg Task Age (min)** \u2014 estimated average age of currently-pending tasks (time spent waiting in the queue). Computed via Little's Law: `pending / rate(completed[1h]) / 60`. Steady-state proxy \u2014 we don't have per-task timestamps, so this is the expected wait under current throughput, not a true measurement. Idle pools (pending=0) show **0.0**; pools with a backlog but no completions in the last hour show \u2014.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "gray",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "24h Peak"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Task Age (min)"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 170
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "noValue",
+                "value": "\u2014"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "\u2014"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 2
+      },
+      "id": 510,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Queue",
+            "Active"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-b-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_running_workers{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-b-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "max_over_time(sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-b-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))[24h:])",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "(\n  sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-b-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))\n  /\n  (sum by (pool) (label_replace(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-b-.*\"}[1h]), \"pool\", \"$1\", \"workerType\", \"(.*)\")) > 0)\n  / 60\n)\nor\nsum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-b-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\")) == 0",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "Pool Queues",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "pool",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true
+            },
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 1,
+              "Value #C": 3,
+              "Value #D": 4,
+              "pool": 0
+            },
+            "renameByName": {
+              "Value #A": "Queue",
+              "Value #B": "Active",
+              "Value #C": "24h Peak",
+              "Value #D": "Avg Task Age (min)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "mac",
+    "macos",
+    "status",
+    "builders"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-b-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mac Builders Status",
+  "uid": "mac-builders-status-v1",
+  "version": 4
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-signers-metrics.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-signers-metrics.json
@@ -1,0 +1,419 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1115,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host CPU, memory, disk, and network latency timeseries for Mac signer workers",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "CPU utilization for host **${hostname}** (macOS). Single series, 0\u2013100%.\n\n**Series:**\n- **CPU %** \u2014 `snmp-load-average` check, metric `cpu_prct_used`.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "CPU %",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-load\" and r.service == \"snmp-load-average\" and r.metric == \"cpu_prct_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"CPU %\" }))\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Memory and disk usage for host **${hostname}** (macOS). Bytes (decimal).\n\n**Series:**\n- **RAM Used** \u2014 `snmp-memory-usage`, metric `ram_used` (KB \u2192 bytes).\n- **Swap Used** \u2014 `snmp-memory-usage`, metric `swap_used` (KB \u2192 bytes).\n- **Disk <metric>** \u2014 `snmp-disk` (measurement `snmp-storage`); one series per disk metric tag (e.g., `used`, `total`).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Bytes",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 3
+          },
+          "id": 202,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "ram = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"ram_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"RAM Used\"}))\n\nswap = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"swap_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"Swap Used\"}))\n\ndisk = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-storage\" and r.service == \"snmp-disk\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value), series: \"Disk \" + r.metric}))\n\nunion(tables: [ram, swap, disk])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory and Disk",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Network round-trip and SSH connection time for host **${hostname}** (macOS), milliseconds.\n\n**Series:**\n- **Ping RTA** \u2014 `hostalive` ping round-trip time (ms).\n- **SSH Time** \u2014 `ssh` check connection time (scaled to ms).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Milliseconds",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 3
+          },
+          "id": 203,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "rta = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r.metric == \"rta\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"Ping RTA\" }))\n\nsshTime = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"ssh\" and r.service == \"ssh\" and r.metric == \"time\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value) * 1000.0, series: \"SSH Time\" }))\n\nunion(tables: [rta, sshTime])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Network Latency",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "hostname",
+      "repeatDirection": "v",
+      "title": "${hostname}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "mac",
+    "macos",
+    "metrics",
+    "cpu",
+    "ram",
+    "disk",
+    "signers"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mac Signers Metrics",
+  "uid": "mac-signers-metrics-v1",
+  "version": 1
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-signers-status.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-signers-status.json
@@ -1,0 +1,1213 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1114,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host status for Mac signer workers \u2014 pool/host filters apply to all panels below",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-host status for pool **${pool}** (Mac signer; matches `signer` in pool name). One row per host expected to report (anchored on `hostalive` over the last 1h, host filter `^macmini-`). Service columns show the last state in the last 10 minutes. Grey \u25cf = no data / host fell off the short window.\n\n**Columns:**\n- **Hostname** \u2014 FQDN of the Mac worker as Icinga reports it.\n- **Up** \u2014 `hostalive` state. Green=Up, Red=Down, Yellow=Unreachable, Grey=no data.\n- **SSH** \u2014 `ssh` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Load** \u2014 `snmp-load-average` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Memory** \u2014 `snmp-memory-usage` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Disk** \u2014 `snmp-disk` check (measurement `snmp-storage`). Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **GW** \u2014 `Mac Generic Worker` check (measurement `snmp_gw_status`). Green=OK (taking work), Yellow=Warn, Red=Crit, Grey=Unknown/no data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hostname"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hostname"
+              },
+              {
+                "id": "custom.width",
+                "value": 360
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Up"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SSH"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Load"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 80
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disk"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GW"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 410,
+      "maxPerRow": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "repeat": "pool",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^macmini-/\n\nexpectedHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npool = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Pool\", v: r._value}))\n\nup = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Up\", v: string(v: r._value)}))\n\nmkService = (m, s, col) =>\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -10m)\n    |> filter(fn: (r) => r._measurement == m and r.service == s and r._field == \"state\")\n    |> filter(fn: hostFilter)\n    |> last()\n    |> map(fn: (r) => ({hostname: r.hostname, k: col, v: string(v: r._value)}))\n\nssh = mkService(m: \"ssh\", s: \"ssh\", col: \"SSH\")\nload = mkService(m: \"snmp-load\", s: \"snmp-load-average\", col: \"Load\")\nmem = mkService(m: \"snmp-memory\", s: \"snmp-memory-usage\", col: \"Memory\")\ndisk = mkService(m: \"snmp-storage\", s: \"snmp-disk\", col: \"Disk\")\ngw = mkService(m: \"snmp_gw_status\", s: \"Mac Generic Worker\", col: \"GW\")\n\nunion(tables: [expectedHosts, pool, up, ssh, load, mem, disk, gw])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       Pool: if exists r.Pool then r.Pool else \"Unknown\",\n       Up: if exists r.Up then r.Up else \"\",\n       SSH: if exists r.SSH then r.SSH else \"\",\n       Load: if exists r.Load then r.Load else \"\",\n       Memory: if exists r.Memory then r.Memory else \"\",\n       Disk: if exists r.Disk then r.Disk else \"\",\n       GW: if exists r.GW then r.GW else \"\"\n     }))\n  |> filter(fn: (r) => r.Pool == \"${pool}\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> sort(columns: [\"hostname\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "${pool}",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Pool": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Disk": 5,
+              "GW": 6,
+              "Load": 3,
+              "Memory": 4,
+              "SSH": 2,
+              "Up": 0,
+              "hostname": 1
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-pool count of Mac signer workers (pool name matches `signer`) currently Available vs. Not Available, based on the Mac Generic Worker (`snmp_gw_status`) check state in the last 15 minutes.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID from the `host_pool` InfluxDB measurement.\n- **Available (15 Minute Window)** \u2014 count of signer hosts whose Mac Generic Worker check reported OK (state=0) at any point in the last 15 minutes.\n- **Not Available** \u2014 count of signer hosts whose Mac Generic Worker check did NOT report OK in the last 15 minutes (warn/crit/unknown or no data).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.wrapHeaderText",
+                "value": true
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              },
+              {
+                "id": "displayName",
+                "value": "Available (15 Minute Window)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Not Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 2
+      },
+      "id": 500,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Available",
+            "Not Available"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^macmini-/\n\nallHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npoolRecords = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"pool\", v: r._value}))\n\ngwAvailability = from(bucket: \"marlin-icinga2\")\n  |> range(start: -15m)\n  |> filter(fn: (r) => r._measurement == \"snmp_gw_status\" and r.service == \"Mac Generic Worker\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> group(columns: [\"hostname\"])\n  |> min(column: \"_value\")\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"gwAvail\", v: if r._value == 0 then \"yes\" else \"no\"}))\n\ncombined = union(tables: [allHosts, poolRecords, gwAvailability])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       pool: if exists r.pool then r.pool else \"Unknown\",\n       gwAvail: if exists r.gwAvail then r.gwAvail else \"no\"\n     }))\n\navailable = combined\n  |> filter(fn: (r) => r.gwAvail == \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Available\", n: r.hostname}))\n\nnotAvailable = combined\n  |> filter(fn: (r) => r.gwAvail != \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Not Available\", n: r.hostname}))\n\nunion(tables: [available, notAvailable])\n  |> group()\n  |> pivot(rowKey: [\"pool\"], columnKey: [\"kind\"], valueColumn: \"n\")\n  |> map(fn: (r) => ({\n       pool: r.pool,\n       Available: if exists r.Available then r.Available else 0,\n       \"Not Available\": if exists r[\"Not Available\"] then r[\"Not Available\"] else 0\n     }))\n  |> filter(fn: (r) => r.pool =~ /signer/)\n  |> sort(columns: [\"pool\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Available": 1,
+              "Not Available": 2,
+              "pool": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "Live queue depth and worker activity per Mac signer pool, sourced from Prometheus (`fxci_queue_*` metrics). Filtered to `provisionerId=releng-hardware`, `workerType=~.*osx.*`, `workerType=~.*signer.*`.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID derived from the Prometheus `workerType` label.\n- **Active** \u2014 `fxci_queue_running_workers`: current count of running workers.\n- **Queue** \u2014 `fxci_queue_pending_tasks`: current count of pending tasks.\n- **24h Peak** \u2014 `max_over_time(...[24h:])` of pending tasks; highest queue depth seen in the last 24 hours.\n- **Avg Task Age (min)** \u2014 estimated average age of currently-pending tasks (time spent waiting in the queue). Computed via Little's Law: `pending / rate(completed[1h]) / 60`. Steady-state proxy \u2014 we don't have per-task timestamps, so this is the expected wait under current throughput, not a true measurement. Idle pools (pending=0) show **0.0**; pools with a backlog but no completions in the last hour show \u2014.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "gray",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "24h Peak"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Task Age (min)"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 170
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "noValue",
+                "value": "\u2014"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "\u2014"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 2
+      },
+      "id": 510,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Queue",
+            "Active"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*signer.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_running_workers{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*signer.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "max_over_time(sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*signer.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))[24h:])",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "(\n  sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*signer.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))\n  /\n  (sum by (pool) (label_replace(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*signer.*\"}[1h]), \"pool\", \"$1\", \"workerType\", \"(.*)\")) > 0)\n  / 60\n)\nor\nsum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*signer.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\")) == 0",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "Pool Queues",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "pool",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true
+            },
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 1,
+              "Value #C": 3,
+              "Value #D": 4,
+              "pool": 0
+            },
+            "renameByName": {
+              "Value #A": "Queue",
+              "Value #B": "Active",
+              "Value #C": "24h Peak",
+              "Value #D": "Avg Task Age (min)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "mac",
+    "macos",
+    "status",
+    "signers"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /signer/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mac Signers Status",
+  "uid": "mac-signers-status-v1",
+  "version": 4
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-testers-metrics.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-testers-metrics.json
@@ -1,0 +1,419 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1111,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host CPU, memory, disk, and network latency timeseries for Mac tester workers",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "CPU utilization for host **${hostname}** (macOS). Single series, 0\u2013100%.\n\n**Series:**\n- **CPU %** \u2014 `snmp-load-average` check, metric `cpu_prct_used`.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "CPU %",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-load\" and r.service == \"snmp-load-average\" and r.metric == \"cpu_prct_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"CPU %\" }))\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Memory and disk usage for host **${hostname}** (macOS). Bytes (decimal).\n\n**Series:**\n- **RAM Used** \u2014 `snmp-memory-usage`, metric `ram_used` (KB \u2192 bytes).\n- **Swap Used** \u2014 `snmp-memory-usage`, metric `swap_used` (KB \u2192 bytes).\n- **Disk <metric>** \u2014 `snmp-disk` (measurement `snmp-storage`); one series per disk metric tag (e.g., `used`, `total`).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Bytes",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 3
+          },
+          "id": 202,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "ram = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"ram_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"RAM Used\"}))\n\nswap = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-memory\" and r.service == \"snmp-memory-usage\" and r.metric == \"swap_used\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value) * 1024.0, series: \"Swap Used\"}))\n\ndisk = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"snmp-storage\" and r.service == \"snmp-disk\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> map(fn: (r) => ({_time: r._time, _value: float(v: r._value), series: \"Disk \" + r.metric}))\n\nunion(tables: [ram, swap, disk])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory and Disk",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Network round-trip and SSH connection time for host **${hostname}** (macOS), milliseconds.\n\n**Series:**\n- **Ping RTA** \u2014 `hostalive` ping round-trip time (ms).\n- **SSH Time** \u2014 `ssh` check connection time (scaled to ms).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Milliseconds",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 3
+          },
+          "id": 203,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "rta = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r.metric == \"rta\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"Ping RTA\" }))\n\nsshTime = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"ssh\" and r.service == \"ssh\" and r.metric == \"time\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value) * 1000.0, series: \"SSH Time\" }))\n\nunion(tables: [rta, sshTime])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Network Latency",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "hostname",
+      "repeatDirection": "v",
+      "title": "${hostname}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "mac",
+    "macos",
+    "metrics",
+    "cpu",
+    "ram",
+    "disk",
+    "testers"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mac Testers Metrics",
+  "uid": "mac-testers-metrics-v1",
+  "version": 1
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-testers-status.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-testers-status.json
@@ -1,0 +1,1213 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1110,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Per-host status for Mac tester workers \u2014 pool/host filters apply to all panels below",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-host status for pool **${pool}** (Mac tester; matches `-t-` in pool name). One row per host expected to report (anchored on `hostalive` over the last 1h, host filter `^macmini-`). Service columns show the last state in the last 10 minutes. Grey \u25cf = no data / host fell off the short window.\n\n**Columns:**\n- **Hostname** \u2014 FQDN of the Mac worker as Icinga reports it.\n- **Up** \u2014 `hostalive` state. Green=Up, Red=Down, Yellow=Unreachable, Grey=no data.\n- **SSH** \u2014 `ssh` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Load** \u2014 `snmp-load-average` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Memory** \u2014 `snmp-memory-usage` check. Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Disk** \u2014 `snmp-disk` check (measurement `snmp-storage`). Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **GW** \u2014 `Mac Generic Worker` check (measurement `snmp_gw_status`). Green=OK (taking work), Yellow=Warn, Red=Crit, Grey=Unknown/no data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hostname"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hostname"
+              },
+              {
+                "id": "custom.width",
+                "value": 360
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Up"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SSH"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Load"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 80
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disk"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GW"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 410,
+      "maxPerRow": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "repeat": "pool",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^macmini-/\n\nexpectedHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npool = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Pool\", v: r._value}))\n\nup = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Up\", v: string(v: r._value)}))\n\nmkService = (m, s, col) =>\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -10m)\n    |> filter(fn: (r) => r._measurement == m and r.service == s and r._field == \"state\")\n    |> filter(fn: hostFilter)\n    |> last()\n    |> map(fn: (r) => ({hostname: r.hostname, k: col, v: string(v: r._value)}))\n\nssh = mkService(m: \"ssh\", s: \"ssh\", col: \"SSH\")\nload = mkService(m: \"snmp-load\", s: \"snmp-load-average\", col: \"Load\")\nmem = mkService(m: \"snmp-memory\", s: \"snmp-memory-usage\", col: \"Memory\")\ndisk = mkService(m: \"snmp-storage\", s: \"snmp-disk\", col: \"Disk\")\ngw = mkService(m: \"snmp_gw_status\", s: \"Mac Generic Worker\", col: \"GW\")\n\nunion(tables: [expectedHosts, pool, up, ssh, load, mem, disk, gw])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       Pool: if exists r.Pool then r.Pool else \"Unknown\",\n       Up: if exists r.Up then r.Up else \"\",\n       SSH: if exists r.SSH then r.SSH else \"\",\n       Load: if exists r.Load then r.Load else \"\",\n       Memory: if exists r.Memory then r.Memory else \"\",\n       Disk: if exists r.Disk then r.Disk else \"\",\n       GW: if exists r.GW then r.GW else \"\"\n     }))\n  |> filter(fn: (r) => r.Pool == \"${pool}\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> sort(columns: [\"hostname\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "${pool}",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Pool": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Disk": 5,
+              "GW": 6,
+              "Load": 3,
+              "Memory": 4,
+              "SSH": 2,
+              "Up": 0,
+              "hostname": 1
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-pool count of Mac tester workers (pool name matches `-t-`) currently Available vs. Not Available, based on the Mac Generic Worker (`snmp_gw_status`) check state in the last 15 minutes.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID from the `host_pool` InfluxDB measurement.\n- **Available (15 Minute Window)** \u2014 count of tester hosts whose Mac Generic Worker check reported OK (state=0) at any point in the last 15 minutes.\n- **Not Available** \u2014 count of tester hosts whose Mac Generic Worker check did NOT report OK in the last 15 minutes (warn/crit/unknown or no data).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.wrapHeaderText",
+                "value": true
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              },
+              {
+                "id": "displayName",
+                "value": "Available (15 Minute Window)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Not Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 2
+      },
+      "id": 500,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Available",
+            "Not Available"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /^macmini-/\n\nallHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npoolRecords = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"pool\", v: r._value}))\n\ngwAvailability = from(bucket: \"marlin-icinga2\")\n  |> range(start: -15m)\n  |> filter(fn: (r) => r._measurement == \"snmp_gw_status\" and r.service == \"Mac Generic Worker\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> group(columns: [\"hostname\"])\n  |> min(column: \"_value\")\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"gwAvail\", v: if r._value == 0 then \"yes\" else \"no\"}))\n\ncombined = union(tables: [allHosts, poolRecords, gwAvailability])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       pool: if exists r.pool then r.pool else \"Unknown\",\n       gwAvail: if exists r.gwAvail then r.gwAvail else \"no\"\n     }))\n\navailable = combined\n  |> filter(fn: (r) => r.gwAvail == \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Available\", n: r.hostname}))\n\nnotAvailable = combined\n  |> filter(fn: (r) => r.gwAvail != \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Not Available\", n: r.hostname}))\n\nunion(tables: [available, notAvailable])\n  |> group()\n  |> pivot(rowKey: [\"pool\"], columnKey: [\"kind\"], valueColumn: \"n\")\n  |> map(fn: (r) => ({\n       pool: r.pool,\n       Available: if exists r.Available then r.Available else 0,\n       \"Not Available\": if exists r[\"Not Available\"] then r[\"Not Available\"] else 0\n     }))\n  |> filter(fn: (r) => r.pool =~ /-t-/)\n  |> sort(columns: [\"pool\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Available": 1,
+              "Not Available": 2,
+              "pool": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "Live queue depth and worker activity per Mac tester pool, sourced from Prometheus (`fxci_queue_*` metrics). Filtered to `provisionerId=releng-hardware`, `workerType=~.*osx.*`, `workerType=~.*-t-.*`.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID derived from the Prometheus `workerType` label.\n- **Active** \u2014 `fxci_queue_running_workers`: current count of running workers.\n- **Queue** \u2014 `fxci_queue_pending_tasks`: current count of pending tasks.\n- **24h Peak** \u2014 `max_over_time(...[24h:])` of pending tasks; highest queue depth seen in the last 24 hours.\n- **Avg Task Age (min)** \u2014 estimated average age of currently-pending tasks (time spent waiting in the queue). Computed via Little's Law: `pending / rate(completed[1h]) / 60`. Steady-state proxy \u2014 we don't have per-task timestamps, so this is the expected wait under current throughput, not a true measurement. Idle pools (pending=0) show **0.0**; pools with a backlog but no completions in the last hour show \u2014.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "gray",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "24h Peak"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Task Age (min)"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 170
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "noValue",
+                "value": "\u2014"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "\u2014"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 2
+      },
+      "id": 510,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Queue",
+            "Active"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-t-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_running_workers{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-t-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "max_over_time(sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-t-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))[24h:])",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "(\n  sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-t-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))\n  /\n  (sum by (pool) (label_replace(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-t-.*\"}[1h]), \"pool\", \"$1\", \"workerType\", \"(.*)\")) > 0)\n  / 60\n)\nor\nsum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\", workerType=~\".*-t-.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\")) == 0",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "Pool Queues",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "pool",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true
+            },
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 1,
+              "Value #C": 3,
+              "Value #D": 4,
+              "pool": 0
+            },
+            "renameByName": {
+              "Value #A": "Queue",
+              "Value #B": "Active",
+              "Value #C": "24h Peak",
+              "Value #D": "Avg Task Age (min)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "mac",
+    "macos",
+    "status",
+    "testers"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /^macmini-/)\n  |> filter(fn: (r) => r._value =~ /-t-/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mac Testers Status",
+  "uid": "mac-testers-status-v1",
+  "version": 4
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-worker-pools-hourly-queue-peak-avg-pickup-wait.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/mac/mac-worker-pools-hourly-queue-peak-avg-pickup-wait.json
@@ -1,0 +1,264 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1119,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Hourly peak queue depth and hourly average estimated pickup wait, per Mac releng-hardware worker pool",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "description": "Hourly peak queued tasks and hourly average estimated pickup wait for pool **${pool}** (macOS / releng-hardware). Both computed over rolling 1h windows sampled every 5 minutes.\n\n- **Hourly Peak Queued** \u2014 `max_over_time(pending_tasks[1h:5m])`. Highest pending-task count seen in the last hour. Left axis, count.\n- **Hourly Avg Time to Pickup** \u2014 `avg_over_time((pending / rate(completed[15m]) / 60)[1h:5m])`. Average Little's Law pickup-wait estimate (minutes) over the last hour. Right axis, minutes. Idle pools (pending=0) show 0; steady-state assumption applies.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Peak Queued"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Tasks queued"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Avg Time to Pickup"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "m"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Pickup wait (min)"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "max_over_time(sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"})[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Peak Queued",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "avg_over_time((\n  (\n    sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"})\n    /\n    (sum(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"}[15m])) > 0)\n    / 60\n  )\n  or\n  (sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"}) == 0)\n)[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Avg Time to Pickup",
+              "refId": "B"
+            }
+          ],
+          "title": "",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "pool",
+      "title": "${pool}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "mac",
+    "macos",
+    "releng-hardware",
+    "pickup-wait",
+    "timeline"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "definition": "label_values(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\"}, workerType)",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "label_values(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*osx.*\"}, workerType)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mac Worker Pools \u2014 Hourly Queue Peak & Avg Pickup Wait",
+  "uid": "mac-pickup-wait-timeline-v1",
+  "version": 5
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-all-metrics.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-all-metrics.json
@@ -1,0 +1,387 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1095,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.4.2",
+      "title": "Per-host CPU, thermal, memory, and disk timeseries for Windows wintest workers",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "CPU utilization and thermal time series for host **${hostname}** (Windows). Two series on dual axes.\n\n**Series:**\n- **CPU 1m %** \u2014 `Windows CPU (1m avg)` (NSClient++). Left axis, 0\u2013100%.\n- **Temp HP C** \u2014 `Windows Thermal (HighPrecision)` (NRPE), metric `temp_hp_c`. Right axis, \u00b0C.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "^CPU 1m %$"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "CPU %"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "^Temp HP C$"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "celsius"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Temp \u00b0C"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "cpu_1m = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"nscp\" and r.service == \"Windows CPU (1m avg)\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"CPU 1m %\" }))\n\ntemp_hp = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"nrpe\" and r.service == \"Windows Thermal (HighPrecision)\" and r.metric == \"temp_hp_c\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"Temp HP C\" }))\n\nunion(tables: [cpu_1m, temp_hp])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU and Thermal",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "description": "Memory and disk usage time series for host **${hostname}** (Windows), bytes (decimal).\n\n**Series:**\n- **RAM Used** \u2014 `Windows RAM` (NSClient++), bytes used.\n- **Disk Used** \u2014 `Windows Disk` (NSClient++), bytes used.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Bytes",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "${__field.labels.series}",
+              "mappings": [],
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 202,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "afebxf3unvvggf"
+              },
+              "query": "ram = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"nscp\" and r.service == \"Windows RAM\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"RAM Used\" }))\n\ndisk = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"nscp\" and r.service == \"Windows Disk\" and r._field == \"value\")\n  |> filter(fn: (r) => r.hostname == \"${hostname}\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> map(fn: (r) => ({ r with _value: float(v: r._value), series: \"Disk Used\" }))\n\nunion(tables: [ram, disk])\n  |> group(columns: [\"series\"])\n  |> sort(columns: [\"_time\"])",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory and Disk",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "hostname",
+      "title": "${hostname}",
+      "type": "row"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 42,
+  "tags": [
+    "windows",
+    "wintest",
+    "metrics",
+    "cpu",
+    "ram",
+    "disk",
+    "thermal"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Windows All Metrics",
+  "uid": "windows-all-metrics-v1",
+  "version": 4,
+  "weekStart": ""
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-all-status.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-all-status.json
@@ -1,0 +1,1090 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1094,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.4.2",
+      "title": "Per-host status for Windows wintest workers \u2014 pool/host filters apply to all panels below",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-pool count of Windows workers (wintest) currently Available vs. Not Available, based on the Windows Generic Worker check state in the last 15 minutes.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID from the `host_pool` InfluxDB measurement. Hosts without a pool record are bucketed as `Unknown`.\n- **Available (15 Minute Window)** \u2014 count of hosts whose Generic Worker check reported OK (state=0) at any point in the last 15 minutes.\n- **Not Available** \u2014 count of hosts whose Generic Worker check did NOT report OK in the last 15 minutes (warn/crit/unknown or no data).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.wrapHeaderText",
+                "value": true
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              },
+              {
+                "id": "displayName",
+                "value": "Available (15 Minute Window)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Not Available"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 2
+      },
+      "id": 500,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Available",
+            "Not Available"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /wintest/\n\nallHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npoolRecords = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"pool\", v: r._value}))\n\ngwAvailability = from(bucket: \"marlin-icinga2\")\n  |> range(start: -15m)\n  |> filter(fn: (r) => r._measurement == \"nscp\" and r.service == \"Windows Generic Worker\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> group(columns: [\"hostname\"])\n  |> min(column: \"_value\")\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"gwAvail\", v: if r._value == 0 then \"yes\" else \"no\"}))\n\ncombined = union(tables: [allHosts, poolRecords, gwAvailability])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       pool: if exists r.pool then r.pool else \"Unknown\",\n       gwAvail: if exists r.gwAvail then r.gwAvail else \"no\"\n     }))\n\navailable = combined\n  |> filter(fn: (r) => r.gwAvail == \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Available\", n: r.hostname}))\n\nnotAvailable = combined\n  |> filter(fn: (r) => r.gwAvail != \"yes\")\n  |> group(columns: [\"pool\"])\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({pool: r.pool, kind: \"Not Available\", n: r.hostname}))\n\nunion(tables: [available, notAvailable])\n  |> group()\n  |> pivot(rowKey: [\"pool\"], columnKey: [\"kind\"], valueColumn: \"n\")\n  |> map(fn: (r) => ({\n       pool: r.pool,\n       Available: if exists r.Available then r.Available else 0,\n       \"Not Available\": if exists r[\"Not Available\"] then r[\"Not Available\"] else 0\n     }))\n  |> sort(columns: [\"pool\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Available": 1,
+              "Not Available": 2,
+              "pool": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "Live queue depth and worker activity per Windows pool, sourced from Prometheus (`fxci_queue_*` metrics). Filtered to `provisionerId=releng-hardware`, `workerType=~.*win.*`, excluding win7.\n\n**Columns:**\n- **Pool** \u2014 worker pool ID derived from the Prometheus `workerType` label.\n- **Active** \u2014 `fxci_queue_running_workers`: current count of running workers.\n- **Queue** \u2014 `fxci_queue_pending_tasks`: current count of pending tasks.\n- **24h Peak** \u2014 `max_over_time(...[24h:])` of pending tasks; highest queue depth seen in the last 24 hours.\n- **Avg Task Age (min)** \u2014 estimated average age of currently-pending tasks (time spent waiting in the queue). Computed via Little's Law: `pending / rate(completed[1h]) / 60`. Steady-state proxy \u2014 we don't have per-task timestamps, so this is the expected wait under current throughput, not a true measurement. Idle pools (pending=0) show **0.0**; pools with a backlog but no completions in the last hour show \u2014.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pool"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Pool"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": []
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "gray",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "24h Peak"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Task Age (min)"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 170
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "noValue",
+                "value": "\u2014"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "\u2014"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 2
+      },
+      "id": 510,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "Queue",
+            "Active"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pool"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "sum by (pool) (label_replace(fxci_queue_running_workers{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "max_over_time(sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))[24h:])",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "expr": "(\n  sum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\"))\n  /\n  (sum by (pool) (label_replace(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}[1h]), \"pool\", \"$1\", \"workerType\", \"(.*)\")) > 0)\n  / 60\n)\nor\nsum by (pool) (label_replace(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}, \"pool\", \"$1\", \"workerType\", \"(.*)\")) == 0",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "Pool Queues",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "pool",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true
+            },
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 1,
+              "Value #C": 3,
+              "Value #D": 4,
+              "pool": 0
+            },
+            "renameByName": {
+              "Value #A": "Queue",
+              "Value #B": "Active",
+              "Value #C": "24h Peak",
+              "Value #D": "Avg Task Age (min)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Per-host status for pool **${pool}**. One row per Windows host expected to report (anchored on `hostalive` over the last 1h). Service columns show the worst state observed in the last 10 minutes. Grey \u25cf = no data / host fell off the short window.\n\n**Columns:**\n- **Hostname** \u2014 FQDN of the Windows worker as Icinga reports it.\n- **Up** \u2014 `hostalive` state. Green=Up, Red=Down, Yellow=Unreachable, Grey=no data.\n- **Bootstrap** \u2014 `Windows Bootstrap Stage` (nrpe). Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Screen** \u2014 `Windows Screen` (nrpe). Green=OK, Yellow=Warn, Red=Crit, Grey=Unknown/no data.\n- **Generic Worker** \u2014 `Windows Generic Worker` (nscp). Green=OK (taking work), Yellow=Warn, Red=Crit, Grey=Unknown/no data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hostname"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hostname"
+              },
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Up"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 60
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Bootstrap"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 90
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Screen"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 70
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Generic Worker"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 110
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "\u25cf"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "text": "\u25cf"
+                      },
+                      "2": {
+                        "color": "red",
+                        "text": "\u25cf"
+                      },
+                      "3": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "match": "empty",
+                      "result": {
+                        "color": "gray",
+                        "text": "\u25cf"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 410,
+      "maxPerRow": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "repeat": "pool",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /wintest/\n\nexpectedHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> map(fn: (r) => ({hostname: r._value, k: \"_anchor\", v: \"\"}))\n\npool = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Pool\", v: r._value}))\n\nup = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"hostalive\" and r._field == \"state\")\n  |> filter(fn: hostFilter)\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, k: \"Up\", v: string(v: r._value)}))\n\nmkService = (m, s, col) =>\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -10m)\n    |> filter(fn: (r) => r._measurement == m and r.service == s and r._field == \"state\")\n    |> filter(fn: hostFilter)\n    |> last()\n    |> map(fn: (r) => ({hostname: r.hostname, k: col, v: string(v: r._value)}))\n\nmkServiceMin = (m, s, col) =>\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -10m)\n    |> filter(fn: (r) => r._measurement == m and r.service == s and r._field == \"state\")\n    |> filter(fn: hostFilter)\n    |> group(columns: [\"hostname\"])\n    |> min(column: \"_value\")\n    |> map(fn: (r) => ({hostname: r.hostname, k: col, v: string(v: r._value)}))\n\nbootstrap = mkServiceMin(m: \"nrpe\", s: \"Windows Bootstrap Stage\", col: \"Bootstrap\")\nscreen = mkService(m: \"nrpe\", s: \"Windows Screen\", col: \"Screen\")\ngw = mkServiceMin(m: \"nscp\", s: \"Windows Generic Worker\", col: \"Generic Worker\")\n\nunion(tables: [expectedHosts, pool, up, bootstrap, screen, gw])\n  |> group()\n  |> pivot(rowKey: [\"hostname\"], columnKey: [\"k\"], valueColumn: \"v\")\n  |> drop(columns: [\"_anchor\"])\n  |> map(fn: (r) => ({\n       hostname: r.hostname,\n       Pool: if exists r.Pool then r.Pool else \"Unknown\",\n       Up: if exists r.Up then r.Up else \"\",\n       Bootstrap: if exists r.Bootstrap then r.Bootstrap else \"\",\n       Screen: if exists r.Screen then r.Screen else \"\",\n       \"Generic Worker\": if exists r[\"Generic Worker\"] then r[\"Generic Worker\"] else \"\"\n     }))\n  |> filter(fn: (r) => r.Pool == \"${pool}\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> sort(columns: [\"hostname\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "${pool}",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Pool": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Bootstrap": 2,
+              "Generic Worker": 4,
+              "Screen": 3,
+              "Up": 0,
+              "hostname": 1
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 42,
+  "tags": [
+    "windows",
+    "wintest",
+    "status"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "import \"experimental/array\"\n\nactualPools = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: (r) => r.hostname =~ /wintest/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> map(fn: (r) => ({_value: r._value, sk: \"0_\" + r._value}))\n\nunknownRow = array.from(rows: [{_value: \"Unknown\", sk: \"1_Unknown\"}])\n\nunion(tables: [actualPools, unknownRow])\n  |> sort(columns: [\"sk\"])\n  |> keep(columns: [\"_value\"])",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "import \"experimental/array\"\n\nactualPools = from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: (r) => r.hostname =~ /wintest/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> keep(columns: [\"_value\"])\n  |> map(fn: (r) => ({_value: r._value, sk: \"0_\" + r._value}))\n\nunknownRow = array.from(rows: [{_value: \"Unknown\", sk: \"1_Unknown\"}])\n\nunion(tables: [actualPools, unknownRow])\n  |> sort(columns: [\"sk\"])\n  |> keep(columns: [\"_value\"])",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: (r) => r.hostname =~ /wintest/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: (r) => r.hostname =~ /wintest/)\n  |> filter(fn: (r) => r._value =~ /^${pool:regex}$/)\n  |> last()\n  |> keep(columns: [\"hostname\"])\n  |> group()\n  |> distinct(column: \"hostname\")\n  |> sort()",
+          "refId": "Var-Hostname"
+        },
+        "refresh": 2,
+        "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Windows All Status",
+  "uid": "windows-all-resource-v3",
+  "version": 20,
+  "weekStart": ""
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-hosts-98-c-24h.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-hosts-98-c-24h.json
@@ -1,0 +1,372 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1105,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.4.2",
+      "title": "Windows wintest hosts that hit \u2265 98\u00b0C in the last 24 hours, grouped by pool",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [],
+      "repeat": "pool",
+      "title": "${pool}",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Count of Windows wintest hosts in pool **${pool}** that hit \u2265 98\u00b0C (high-precision thermal) at any point in the dashboard time range (default last 24h). Color: Green=0, Orange=1\u20139, Red=10+.\n\nData source: `Windows Thermal (HighPrecision)` NRPE check, metric `temp_hp_c`. Pool membership joined from the `host_pool` measurement.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /wintest/\n\nhot = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"nrpe\" and r.service == \"Windows Thermal (HighPrecision)\" and r.metric == \"temp_hp_c\" and r._field == \"value\")\n  |> filter(fn: hostFilter)\n  |> group(columns: [\"hostname\"])\n  |> max()\n  |> filter(fn: (r) => float(v: r._value) >= 98.0)\n  |> keep(columns: [\"hostname\", \"_value\"])\n\npoolHosts = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> filter(fn: (r) => r._value == \"${pool}\")\n  |> last()\n  |> keep(columns: [\"hostname\"])\n\njoin(tables: {h: hot, p: poolHosts}, on: [\"hostname\"])\n  |> group()\n  |> count(column: \"hostname\")\n  |> map(fn: (r) => ({_value: r.hostname}))",
+          "refId": "A"
+        }
+      ],
+      "title": "Hosts \u2265 98\u00b0C in ${pool}",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "description": "Wintest hosts in pool **${pool}** that reached \u2265 98\u00b0C in the dashboard time range (default last 24h). Sorted by Max \u00b0C descending.\n\n**Columns:**\n- **Hostname** \u2014 FQDN of the wintest host.\n- **Max \u00b0C** \u2014 peak temperature observed in the range. Color-graded: orange \u2265 0\u00b0C, red \u2265 100\u00b0C.\n- **Peak Time** \u2014 timestamp of the peak temperature reading (ISO).\n- **Pool** \u2014 hidden by the organize transformation; pool membership pulled from `host_pool`.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "no hosts \u2265 98\u00b0C",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hostname"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hostname"
+              },
+              {
+                "id": "custom.width",
+                "value": 420
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MaxC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Max \u00b0C"
+              },
+              {
+                "id": "unit",
+                "value": "celsius"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              },
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background-solid"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "orange",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PeakTime"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Peak Time"
+              },
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
+              },
+              {
+                "id": "custom.width",
+                "value": 240
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pool"
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 201,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": [
+            "hostname"
+          ],
+          "reducer": [
+            "count"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Max \u00b0C"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "hostFilter = (r) => r.hostname =~ /wintest/\n\nhot = from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"nrpe\" and r.service == \"Windows Thermal (HighPrecision)\" and r.metric == \"temp_hp_c\" and r._field == \"value\")\n  |> filter(fn: hostFilter)\n  |> group(columns: [\"hostname\"])\n  |> max()\n  |> filter(fn: (r) => float(v: r._value) >= 98.0)\n  |> map(fn: (r) => ({hostname: r.hostname, MaxC: float(v: r._value), PeakTime: r._time}))\n  |> keep(columns: [\"hostname\", \"MaxC\", \"PeakTime\"])\n\npool = from(bucket: \"marlin-icinga2\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\")\n  |> filter(fn: hostFilter)\n  |> filter(fn: (r) => r._value == \"${pool}\")\n  |> last()\n  |> map(fn: (r) => ({hostname: r.hostname, Pool: r._value}))\n  |> keep(columns: [\"hostname\", \"Pool\"])\n\njoin(tables: {h: hot, p: pool}, on: [\"hostname\"])\n  |> group()\n  |> sort(columns: [\"MaxC\"], desc: true)",
+          "refId": "A"
+        }
+      ],
+      "title": "Hosts that hit \u2265 98\u00b0C",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Pool": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "MaxC": 1,
+              "PeakTime": 2,
+              "hostname": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 42,
+  "tags": [
+    "windows",
+    "wintest",
+    "thermal",
+    "alert"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /wintest/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"host_pool\" and r._field == \"pool\" and r.hostname =~ /wintest/)\n  |> last()\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort()",
+          "refId": "Var-Pool"
+        },
+        "refresh": 2,
+        "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Windows Hosts \u2265 98\u00b0C (24h)",
+  "uid": "windows-thermal-24h-v1",
+  "version": 8,
+  "weekStart": ""
+}

--- a/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-worker-pools-hourly-queue-peak-avg-pickup-wait.json
+++ b/yardstick/gdg-based/dashboards/fxci-hardware-workers/windows/windows-worker-pools-hourly-queue-peak-avg-pickup-wait.json
@@ -1,0 +1,264 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "id": 1117,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "title": "Hourly peak queue depth and hourly average estimated pickup wait, per Windows releng-hardware worker pool",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "description": "Hourly peak queued tasks and hourly average estimated pickup wait for pool **${pool}** (Windows / releng-hardware). Both computed over rolling 1h windows sampled every 5 minutes.\n\n- **Hourly Peak Queued** \u2014 `max_over_time(pending_tasks[1h:5m])`. Highest pending-task count seen in the last hour. Left axis, count.\n- **Hourly Avg Time to Pickup** \u2014 `avg_over_time((pending / rate(completed[15m]) / 60)[1h:5m])`. Average Little's Law pickup-wait estimate (minutes) over the last hour. Right axis, minutes. Idle pools (pending=0) show 0; steady-state assumption applies.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "off",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Peak Queued"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Tasks queued"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hourly Avg Time to Pickup"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "m"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Pickup wait (min)"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.4.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "max_over_time(sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"})[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Peak Queued",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "adpvtjmrxoc1sb"
+              },
+              "expr": "avg_over_time((\n  (\n    sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"})\n    /\n    (sum(rate(fxci_queue_completed_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"}[15m])) > 0)\n    / 60\n  )\n  or\n  (sum(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=\"${pool}\"}) == 0)\n)[1h:5m])",
+              "interval": "1h",
+              "legendFormat": "Hourly Avg Time to Pickup",
+              "refId": "B"
+            }
+          ],
+          "title": "",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "pool",
+      "title": "${pool}",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 42,
+  "tags": [
+    "windows",
+    "wintest",
+    "releng-hardware",
+    "pickup-wait",
+    "timeline"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "definition": "label_values(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}, workerType)",
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "label_values(fxci_queue_pending_tasks{provisionerId=\"releng-hardware\", workerType=~\".*win.*\", workerType!~\".*win7.*\"}, workerType)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Windows Worker Pools \u2014 Hourly Queue Peak & Avg Pickup Wait",
+  "uid": "windows-pickup-wait-timeline-v1",
+  "version": 5
+}

--- a/yardstick/gdg-based/dashboards/relsre-development/all-devices-status.json
+++ b/yardstick/gdg-based/dashboards/relsre-development/all-devices-status.json
@@ -1,0 +1,1146 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1054,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n  |> filter(fn: (r) => r.hostname =~ /nuc/ or r.hostname =~ /^t-w/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> group()\n  |> count(column: \"_value\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Windows Devices",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n  |> filter(fn: (r) => r.hostname =~ /linux/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> group()\n  |> count(column: \"_value\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Linux Devices",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n  |> filter(fn: (r) => r.hostname =~ /mac/ or r.hostname =~ /mojave/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> group()\n  |> count(column: \"_value\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Mac Devices",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n  |> filter(fn: (r) => not (r.hostname =~ /nuc/ or r.hostname =~ /^t-w/) and not r.hostname =~ /linux/ and not (r.hostname =~ /mac/ or r.hostname =~ /mojave/))\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> group()\n  |> count(column: \"_value\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Unknown Devices",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1e-05
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 1e-05,
+                      "result": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Up"
+                      },
+                      "to": 9999
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "Down"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "orange",
+                        "index": 2,
+                        "text": "No Data"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Seen"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Hostname"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pool"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 220
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> filter(fn: (r) => r.hostname =~ /nuc/ or r.hostname =~ /^t-w/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> keep(columns: [\"hostname\", \"_value\", \"_time\"])\n  |> rename(columns: {_value: \"status\"})\n  |> group()",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -7d)\n  |> filter(fn: (r) => r._measurement == \"nrpe\")\n  |> filter(fn: (r) => r.service == \"Windows Worker Pool ID\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> filter(fn: (r) => r.hostname =~ /nuc/ or r.hostname =~ /^t-w/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> keep(columns: [\"hostname\", \"_value\"])\n  |> rename(columns: {_value: \"pool\"})\n  |> group()",
+          "refId": "B"
+        }
+      ],
+      "title": "Windows",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "hostname",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "_time": 2,
+              "hostname": 0,
+              "pool": 3,
+              "status": 1
+            },
+            "renameByName": {
+              "_time": "Last Seen",
+              "hostname": "Hostname",
+              "pool": "Pool",
+              "status": "Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1e-05
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 1e-05,
+                      "result": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Up"
+                      },
+                      "to": 9999
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "Down"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "orange",
+                        "index": 2,
+                        "text": "No Data"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Seen"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Hostname"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> filter(fn: (r) => r.hostname =~ /linux/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> keep(columns: [\"hostname\", \"_value\", \"_time\"])\n  |> rename(columns: {_value: \"status\"})\n  |> group()",
+          "refId": "A"
+        }
+      ],
+      "title": "Linux",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "_time": 2,
+              "hostname": 0,
+              "status": 1
+            },
+            "renameByName": {
+              "_time": "Last Seen",
+              "hostname": "Hostname",
+              "status": "Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1e-05
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 1e-05,
+                      "result": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Up"
+                      },
+                      "to": 9999
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "Down"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "orange",
+                        "index": 2,
+                        "text": "No Data"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Seen"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Hostname"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> filter(fn: (r) => r.hostname =~ /mac/ or r.hostname =~ /mojave/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> keep(columns: [\"hostname\", \"_value\", \"_time\"])\n  |> rename(columns: {_value: \"status\"})\n  |> group()",
+          "refId": "A"
+        }
+      ],
+      "title": "Mac",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "_time": 2,
+              "hostname": 0,
+              "status": 1
+            },
+            "renameByName": {
+              "_time": "Last Seen",
+              "hostname": "Hostname",
+              "status": "Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "afebxf3unvvggf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1e-05
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 1e-05,
+                      "result": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Up"
+                      },
+                      "to": 9999
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "Down"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "color": "orange",
+                        "index": 2,
+                        "text": "No Data"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Seen"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Hostname"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Hostname"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "afebxf3unvvggf"
+          },
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"hostalive\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /^${hostname:regex}$/)\n  |> filter(fn: (r) => not (r.hostname =~ /nuc/ or r.hostname =~ /^t-w/) and not r.hostname =~ /linux/ and not (r.hostname =~ /mac/ or r.hostname =~ /mojave/))\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> keep(columns: [\"hostname\", \"_value\", \"_time\"])\n  |> rename(columns: {_value: \"status\"})\n  |> group()",
+          "refId": "A"
+        }
+      ],
+      "title": "Unknown",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "_time": 2,
+              "hostname": 0,
+              "status": 1
+            },
+            "renameByName": {
+              "_time": "Last Seen",
+              "hostname": "Hostname",
+              "status": "Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 42,
+  "tags": [
+    "status",
+    "all-devices"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": ".*",
+          "value": ".*"
+        },
+        "label": "Host regex",
+        "name": "host_re",
+        "options": [
+          {
+            "selected": true,
+            "text": ".*",
+            "value": ".*"
+          }
+        ],
+        "query": ".*",
+        "type": "custom"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -7d)\n  |> filter(fn: (r) => r._measurement == \"nrpe\")\n  |> filter(fn: (r) => r.service == \"Windows Worker Pool ID\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> keep(columns: [\"_value\"])\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort(columns: [\"_value\"])",
+        "includeAll": true,
+        "label": "Worker Pool",
+        "name": "worker_pool_id",
+        "options": [],
+        "query": {
+          "query": "from(bucket: \"marlin-icinga2\")\n  |> range(start: -7d)\n  |> filter(fn: (r) => r._measurement == \"nrpe\")\n  |> filter(fn: (r) => r.service == \"Windows Worker Pool ID\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n  |> group(columns: [\"hostname\"])\n  |> last()\n  |> keep(columns: [\"_value\"])\n  |> group()\n  |> distinct(column: \"_value\")\n  |> sort(columns: [\"_value\"])"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "afebxf3unvvggf"
+        },
+        "definition": "import \"influxdata/influxdb/schema\"\n\nall_hosts =\n  schema.tagValues(\n    bucket: \"marlin-icinga2\",\n    tag: \"hostname\",\n    predicate: (r) =>\n      r._measurement == \"hostalive\" and\n      r.hostname =~ /${host_re}/\n  )\n    |> rename(columns: {_value: \"hostname\"})\n    |> map(fn: (r) => ({ hostname: r.hostname, worker_pool_id: \"zzz-no-pool\" }))\n\npool_hosts =\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -7d)\n    |> filter(fn: (r) => r._measurement == \"nrpe\")\n    |> filter(fn: (r) => r.service == \"Windows Worker Pool ID\")\n    |> filter(fn: (r) => r._field == \"value\")\n    |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n    |> group(columns: [\"hostname\"])\n    |> last()\n    |> keep(columns: [\"hostname\", \"_value\"])\n    |> rename(columns: {_value: \"worker_pool_id\"})\n\nunion(tables: [all_hosts, pool_hosts])\n  |> group(columns: [\"hostname\"])\n  |> sort(columns: [\"worker_pool_id\"])\n  |> limit(n: 1)\n  |> filter(fn: (r) => r.worker_pool_id =~ /^(${worker_pool_id:regex})$/)\n  |> group()\n  |> sort(columns: [\"worker_pool_id\", \"hostname\"])\n  |> rename(columns: {hostname: \"_value\"})\n  |> keep(columns: [\"_value\"])",
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "import \"influxdata/influxdb/schema\"\n\nall_hosts =\n  schema.tagValues(\n    bucket: \"marlin-icinga2\",\n    tag: \"hostname\",\n    predicate: (r) =>\n      r._measurement == \"hostalive\" and\n      r.hostname =~ /${host_re}/\n  )\n    |> rename(columns: {_value: \"hostname\"})\n    |> map(fn: (r) => ({ hostname: r.hostname, worker_pool_id: \"zzz-no-pool\" }))\n\npool_hosts =\n  from(bucket: \"marlin-icinga2\")\n    |> range(start: -7d)\n    |> filter(fn: (r) => r._measurement == \"nrpe\")\n    |> filter(fn: (r) => r.service == \"Windows Worker Pool ID\")\n    |> filter(fn: (r) => r._field == \"value\")\n    |> filter(fn: (r) => r.hostname =~ /${host_re}/)\n    |> group(columns: [\"hostname\"])\n    |> last()\n    |> keep(columns: [\"hostname\", \"_value\"])\n    |> rename(columns: {_value: \"worker_pool_id\"})\n\nunion(tables: [all_hosts, pool_hosts])\n  |> group(columns: [\"hostname\"])\n  |> sort(columns: [\"worker_pool_id\"])\n  |> limit(n: 1)\n  |> filter(fn: (r) => r.worker_pool_id =~ /^(${worker_pool_id:regex})$/)\n  |> group()\n  |> sort(columns: [\"worker_pool_id\", \"hostname\"])\n  |> rename(columns: {hostname: \"_value\"})\n  |> keep(columns: [\"_value\"])"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "All Devices Status",
+  "uid": "jg4pplj",
+  "version": 2,
+  "weekStart": ""
+}

--- a/yardstick/gdg-based/dashboards/relsre-development/workers.json
+++ b/yardstick/gdg-based/dashboards/relsre-development/workers.json
@@ -1,0 +1,2837 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            9
+          ]
+        },
+        "hide": true,
+        "iconColor": "rgba(72, 72, 72, 0.12)",
+        "name": "Time region for panel Last Task Status",
+        "target": {
+          "queryType": "timeRegions",
+          "refId": "Anno",
+          "timeRegion": {
+            "from": "15:00",
+            "timezone": "utc",
+            "to": "24:00"
+          }
+        }
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            14
+          ]
+        },
+        "hide": true,
+        "iconColor": "rgba(156, 191, 248, 0.07)",
+        "name": "Time region for panel TC Worker Backlog/Workers",
+        "target": {
+          "queryType": "timeRegions",
+          "refId": "Anno",
+          "timeRegion": {
+            "from": "15:00",
+            "timezone": "utc",
+            "to": "24:00"
+          }
+        }
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            3
+          ]
+        },
+        "hide": true,
+        "iconColor": "rgba(156, 191, 248, 0.07)",
+        "name": "Time region for panel Workers vs Active",
+        "target": {
+          "queryType": "timeRegions",
+          "refId": "Anno",
+          "timeRegion": {
+            "from": "15:00",
+            "timezone": "utc",
+            "to": "24:00"
+          }
+        }
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            6
+          ]
+        },
+        "hide": true,
+        "iconColor": "rgba(156, 191, 248, 0.07)",
+        "name": "Time region for panel Queue",
+        "target": {
+          "queryType": "timeRegions",
+          "refId": "Anno",
+          "timeRegion": {
+            "from": "15:00",
+            "timezone": "utc",
+            "to": "24:00"
+          }
+        }
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            10
+          ]
+        },
+        "hide": true,
+        "iconColor": "rgba(156, 191, 248, 0.07)",
+        "name": "Time region for panel Active vs Queue",
+        "target": {
+          "queryType": "timeRegions",
+          "refId": "Anno",
+          "timeRegion": {
+            "from": "15:00",
+            "timezone": "utc",
+            "to": "24:00"
+          }
+        }
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            11
+          ]
+        },
+        "hide": true,
+        "iconColor": "rgba(156, 191, 248, 0.07)",
+        "name": "Time region for panel Active vs Queue",
+        "target": {
+          "queryType": "timeRegions",
+          "refId": "Anno",
+          "timeRegion": {
+            "from": "15:00",
+            "timezone": "utc",
+            "to": "24:00"
+          }
+        }
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 1089,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tasks",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.2,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*exception.*/"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 10
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "failures"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*completed$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(34, 84, 27, 0.55)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 10
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "auto"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "lt",
+                "reducer": "last",
+                "value": 0.1
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 14,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(provisionerId, workerType) (increase(fxci_queue_exception_tasks{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", workerType!~\".*gcp.*\"}[15m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{provisionerId}}/{{workerType}} exceptions",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "expr": "sum by(provisionerId, workerType) (increase(fxci_queue_completed_tasks{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", workerType!~\".*gcp.*\"}[15m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{provisionerId}}/{{workerType}} completed",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Last Task Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false,
+            "wrapText": false
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "workerType"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 310
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "shades"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color"
+              },
+              {
+                "id": "custom.width",
+                "value": 136
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "workerManager page",
+                    "url": "https://firefox-ci-tc.services.mozilla.com/worker-manager/${__data.fields.provisioner}%2F${__data.fields.workerType}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 128
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "workerType"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "filter by provisioner and workerType",
+                    "url": "/d/${__dashboard.uid}\ufeff/${__dashboard}?var-provisioner=${__data.fields.provisioner}&var-workerType=${__data.fields.workerType}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "provisioner"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 174
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "filter by provisioner",
+                    "url": "/d/${__dashboard.uid}\ufeff/${__dashboard}?var-provisioner=${__data.fields.provisioner}&var-workerType=All"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Quar %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 10,
+        "x": 14,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "enablePagination": false,
+        "frameIndex": 0,
+        "renameColumns": {
+          "Value": "workers",
+          "legend": "workerPool"
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Queue"
+          }
+        ],
+        "transform": "rename-columns"
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_pending_tasks{provisionerId!~\"^(releng-hardware|proj-autophone|scriptworker-prov-v1)\", provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_running_workers{provisionerId!~\"^(releng-hardware|proj-autophone|scriptworker-prov-v1)\", provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(sum by(provisioner, workerType) (label_replace(fxci_queue_quarantined_workers{provisionerId!~\"^(releng-hardware|proj-autophone|scriptworker-prov-v1)\", provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\")) / sum by(provisioner, workerType) (label_replace(fxci_queue_workers_total{provisionerId!~\"^(releng-hardware|proj-autophone|scriptworker-prov-v1)\", provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\")) * 100)",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_quarantined_workers{provisionerId!~\"^(releng-hardware|proj-autophone|scriptworker-prov-v1)\", provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "hide": true,
+          "instant": true,
+          "legendFormat": "quar",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_workers_total{provisionerId!~\"^(releng-hardware|proj-autophone|scriptworker-prov-v1)\", provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "hide": true,
+          "instant": true,
+          "legendFormat": "total",
+          "range": false,
+          "refId": "E"
+        }
+      ],
+      "title": "Cloud",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "provisioner": false,
+              "provisionerId": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value #A": 4,
+              "Value #B": 5,
+              "Value #D": 6,
+              "provisioner": 1,
+              "provisionerId": 2,
+              "workerType": 3
+            },
+            "renameByName": {
+              "Time": "",
+              "Value": "Quarantined",
+              "Value #A": "Queue",
+              "Value #B": "Active",
+              "Value #C": "Idle",
+              "Value #D": "Quar %",
+              "provisioner": "",
+              "workerType": ""
+            }
+          }
+        },
+        {
+          "disabled": true,
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "greater",
+                  "options": {
+                    "value": 0
+                  }
+                },
+                "fieldName": "Queue"
+              }
+            ],
+            "match": "all",
+            "type": "include"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "= Queued tasks / workers running tasks\nfiltered to:\nreleng-hardware\naws-provisioner-v1 with /^(mobile|app-services|gecko)-/\nterraform-packet",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tasks/worker",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 110,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": 0
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsNull",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gt",
+                "reducer": "lastNotNull",
+                "value": 100000
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "lt",
+                "reducer": "lastNotNull",
+                "value": 0.1
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 14,
+        "x": 0,
+        "y": 4
+      },
+      "id": 14,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "expr": "sum by(workerType, provisionerId) (avg_over_time(fxci_queue_pending_tasks{provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}[15m]) / avg_over_time(fxci_queue_running_workers{provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}[15m]))",
+          "hide": false,
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{provisionerId}}/{{workerType}} load",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "TC Worker Backlog/Workers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "workers",
+            "axisPlacement": "hidden",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*workers$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*pending$/"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FADE2A",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 50
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*requested$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*active$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*queue$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FA6400",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 40
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "auto"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*max$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(0, 3, 255, 0.15)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    1,
+                    4
+                  ],
+                  "fill": "solid"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*active2$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(115, 191, 105, 0.41)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*queue2$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 20
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*/"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "auto"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*quarantined$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FADE2A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 14,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "expr": "sum by(provisionerId, workerType) (\n  avg_over_time(fxci_queue_running_workers{\n    provisionerId!~\"^gecko.*\",\n    provisionerId!~\".*k8s\",\n    provisionerId=~\"$provisioner\",\n    workerType=~\"$workerType\",\n  }[$__interval])\n) ",
+          "hide": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{provisionerId}}/{{workerType}} active",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "expr": "sum by(provisionerId, workerType) (\n  avg_over_time(fxci_queue_workers_total{\n    provisionerId!~\"^gecko.*\",\n    provisionerId!~\".*k8s\",\n    provisionerId=~\"$provisioner\",\n    workerType=~\"$workerType\",\n  }[$__interval])\n  - \n  avg_over_time(fxci_queue_quarantined_workers{\n    provisionerId!~\"^gecko.*\",\n    provisionerId!~\".*k8s\",\n    provisionerId=~\"$provisioner\",\n    workerType=~\"$workerType\",\n  }[$__interval])\n) ",
+          "hide": false,
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{provisionerId}}/{{workerType}} workers",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "expr": "sum by(provisionerId, workerType) (\n  avg_over_time(fxci_queue_quarantined_workers{\n    provisionerId!~\"^gecko.*\",\n    provisionerId!~\"k8s\",\n    provisionerId=~\"$provisioner\",\n    workerType=~\"$workerType\",\n  }[$__interval])\n) ",
+          "hide": false,
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{provisionerId}}/{{workerType}} quarantined",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Workers vs Active",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "<https://wiki.mozilla.org/CIDuty/How_To/High_Pending_Counts>",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "hidden",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 2000
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*running$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*pending$/"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FADE2A",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 50
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "B",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*requested$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "C",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*active$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "D",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*queue/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(194, 96, 31)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 40
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "auto"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "queued tasks"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*max$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(0, 24, 255)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    1,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*active2$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(115, 191, 105, 0.41)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*alert$/"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "auto"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "queued tasks"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 14,
+        "x": 0,
+        "y": 14
+      },
+      "id": 6,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "sum"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg by(workerType, provisionerId) (fxci_queue_pending_tasks{provisionerId=~\"$provisioner\", workerType=~\"$workerType\"})",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{provisionerId}}/{{workerType}}  queue",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Queue",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "description": "Only shows queue with > 0",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "displayName": "",
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(106, 106, 106, 0.9)",
+                "value": 0
+              },
+              {
+                "color": "rgba(255, 255, 255, 0.89)",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "provisioner"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 131
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "filter by provisioner",
+                    "url": "/d/${__dashboard.uid}\ufeff/${__dashboard}?var-provisioner=${__data.fields.provisioner}&var-workerType=All"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "workerType"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 249
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "filter by provisioner and workerType",
+                    "url": "/d/${__dashboard.uid}\ufeff/${__dashboard}?var-provisioner=${__data.fields.provisioner}&var-workerType=${__data.fields.workerType}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-yellow",
+                      "value": 1000
+                    },
+                    {
+                      "color": "dark-orange",
+                      "value": 1500
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 2000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 77
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "worker page",
+                    "url": "https://firefox-ci-tc.services.mozilla.com/provisioners/${__data.fields.provisioner}/worker-types/${__data.fields.workerType}?sortBy=Last%20Active&sortDirection=desc"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 72
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 57
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Workers"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 73
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Quar%"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "quarantined",
+                    "url": "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/provisioners/${__data.fields.provisioner}/worker-types/${__data.fields.workerType}/workers?limit=1000&quarantined=true"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 117
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 10,
+        "x": 14,
+        "y": 15
+      },
+      "id": 15,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Queue"
+          }
+        ]
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_pending_tasks{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", provisionerId=~\"^(releng-hardware|bitbar|proj-autophone)$\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_running_workers{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", provisionerId=~\"^(releng-hardware|bitbar|proj-autophone)$\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_idle_workers{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", provisionerId=~\"^(releng-hardware|bitbar|proj-autophone)$\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(provisioner, workerType) (label_replace(fxci_queue_workers_total{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", provisionerId=~\"^(releng-hardware|bitbar|proj-autophone)$\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\"))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(sum by(provisioner, workerType) (label_replace(fxci_queue_quarantined_workers{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", provisionerId=~\"^(releng-hardware|bitbar|proj-autophone)$\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\")) / sum by(provisioner, workerType) (label_replace(fxci_queue_workers_total{provisionerId=~\"$provisioner\", workerType=~\"$workerType\", provisionerId=~\"^(releng-hardware|bitbar|proj-autophone)$\"}, \"provisioner\", \"$1\", \"provisionerId\", \"(.*)\")) * 100)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "E"
+        }
+      ],
+      "title": "Hardware",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "provisioner": false,
+              "provisionerId": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 4,
+              "Value #A": 5,
+              "Value #B": 6,
+              "Value #C": 7,
+              "provisioner": 1,
+              "provisionerId": 2,
+              "workerType": 3
+            },
+            "renameByName": {
+              "Time": "",
+              "Value": "",
+              "Value #A": "Queue",
+              "Value #B": "Active",
+              "Value #C": "Idle",
+              "Value #D": "Workers",
+              "Value #E": "Quar%",
+              "provisionerId": ""
+            }
+          }
+        },
+        {
+          "disabled": true,
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "greater",
+                  "options": {
+                    "value": 0
+                  }
+                },
+                "fieldName": "Queue"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "workers",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*running$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*pending$/"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FADE2A",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 50
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "B",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*requested$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "C",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*active$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*queue$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FA6400",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 20
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "queued tasks"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*max$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(0, 24, 255)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    1,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 14,
+        "x": 0,
+        "y": 18
+      },
+      "id": 10,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "sum"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg_over_time(fxci_queue_running_workers{provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}[10m])",
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{workerType}} active",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(fxci_queue_pending_tasks{provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}[1m])",
+          "hide": false,
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{workerType}} queue",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "timeShift": "7d",
+      "title": "Active vs Queue",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adpvtjmrxoc1sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "workers",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*running$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*pending$/"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FADE2A",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 50
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "B",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*requested$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "C",
+                  "mode": "normal"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*active$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*queue$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FA6400",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 20
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "queued tasks"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*max$/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(0, 24, 255)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    1,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 14,
+        "x": 0,
+        "y": 22
+      },
+      "id": 16,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "sum"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg_over_time(fxci_queue_running_workers{provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}[10m])",
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{provisionerId}}/{{workerType}} active",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adpvtjmrxoc1sb"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(fxci_queue_pending_tasks{provisionerId=~\"$provisioner\", workerType=~\"$workerType\"}[1m])",
+          "hide": false,
+          "instant": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{provisionerId}}/{{workerType}} queue",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "timeShift": "4w",
+      "title": "Active vs Queue",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5m",
+  "schemaVersion": 42,
+  "tags": [
+    "owner=relsre",
+    "relsre-backup",
+    "relsre-development",
+    "taskcluster-metrics"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "definition": "label_values(fxci_queue_pending_tasks, provisionerId)",
+        "includeAll": true,
+        "multi": true,
+        "name": "provisioner",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(fxci_queue_pending_tasks, provisionerId)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "definition": "label_values(fxci_queue_pending_tasks{provisionerId=~\"$provisioner\"}, workerType)",
+        "includeAll": true,
+        "multi": true,
+        "name": "workerType",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(fxci_queue_pending_tasks{provisionerId=~\"$provisioner\"}, workerType)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "baseFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "filters": [],
+        "name": "Adhoc",
+        "type": "adhoc"
+      },
+      {
+        "baseFilters": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "adpvtjmrxoc1sb"
+        },
+        "filters": [],
+        "name": "Filters",
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Workers",
+  "uid": "workers-fxci-dev",
+  "version": 8
+}

--- a/yardstick/gdg-based/dashboards/relsre/workers.json
+++ b/yardstick/gdg-based/dashboards/relsre/workers.json
@@ -2824,12 +2824,12 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Workers",
   "uid": "ieg6Sho5",
-  "version": 128
+  "version": 129
 }


### PR DESCRIPTION
## Summary

- Backs up the three RelSRE subfolders that weren't yet tracked in this repo (16 dashboards across 5 grandchild folders).
- Adds a directory map in `yardstick/gdg-based/README.md` so the on-disk layout matches the Grafana folder tree.
- Documents a curl-based fallback for when GDG isn't available locally.

## Folder layout

| Yardstick folder | Tracked dir | Dashboards added |
|---|---|---|
| `RelSRE/FXCI Cloud Workers/Azure` | `dashboards/fxci-cloud-workers/azure/` | 1 |
| `RelSRE/FXCI Cloud Workers/GCP` | `dashboards/fxci-cloud-workers/gcp/` | 1 |
| `RelSRE/FXCI Hardware Workers/Linux` | `dashboards/fxci-hardware-workers/linux/` | 3 |
| `RelSRE/FXCI Hardware Workers/Mac` | `dashboards/fxci-hardware-workers/mac/` | 7 |
| `RelSRE/FXCI Hardware Workers/Windows` | `dashboards/fxci-hardware-workers/windows/` | 4 |
| `RelSRE/RelSRE Development` | `dashboards/relsre-development/` | 2 |

`RelSRE/RelSRE Sandboxes` is intentionally not tracked (personal/test dashboards).

## How exports were generated

GDG wasn't available locally (Docker not running, the placeholder `config/importer.yml` is still committed). Dashboards were pulled directly from the Grafana API using exported browser cookies, then written through `json.dump(d['dashboard'], ..., indent=2, sort_keys=True)` so they match the existing `relsre/` format. The new README section documents this workflow.

## Test plan

- [ ] `find yardstick/gdg-based/dashboards -name '*.json' | xargs -I{} jq empty {}` — all 26 files parse.
- [ ] Spot-check one dashboard from each new subfolder renders in Yardstick (UIDs preserved).
- [ ] README directory map matches the live folder tree.